### PR TITLE
Add a from_env method to SmtpOptions

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -27,3 +27,4 @@ features = ["builder", "hostname", "pool", "rustls-tls", "smtp-transport", "toki
 
 [dev-dependencies]
 iii-iv-core = { path = "../core", features = ["testutils"] }
+temp-env = "0.3.2"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -24,3 +24,4 @@ env_logger = "0.8"
 rand = "0.8"
 tokio = { version = "1", features = ["macros"] }
 iii-iv-core = { path = "../core", features = ["internal", "testutils"] }
+temp-env = "0.3.2"


### PR DESCRIPTION
This mimics what was previously done in PostgresOptions to instantiate the configuration from environment variables.

While doing this, add tests for PostgresOptions, which did not have any.