### PR TITLE
Separate DB pool creation from *Db types

### DIFF
--- a/example/src/driver/testutils.rs
+++ b/example/src/driver/testutils.rs
@@ -17,7 +17,7 @@
 
 use crate::db::sqlite::SqliteTx;
 use crate::driver::Driver;
-use iii_iv_sqlite::SqliteDb;
+use iii_iv_sqlite::{self, SqliteDb};
 
 pub(crate) struct TestContext {
     db: SqliteDb<SqliteTx>,
@@ -26,7 +26,8 @@ pub(crate) struct TestContext {
 
 impl TestContext {
     pub(crate) async fn setup() -> Self {
-        let db = SqliteDb::<SqliteTx>::connect(":memory:").await.unwrap();
+        let pool = iii_iv_sqlite::connect(":memory:").await.unwrap();
+        let db = SqliteDb::<SqliteTx>::attach(pool).await.unwrap();
         let driver = Driver::new(db.clone());
         Self { db, driver }
     }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -20,7 +20,7 @@
 #![warn(unused, unused_extern_crates, unused_import_braces, unused_qualifications)]
 #![warn(unsafe_code)]
 
-use iii_iv_postgres::{PostgresDb, PostgresOptions};
+use iii_iv_postgres::{PostgresDb, PostgresOptions, PostgresPool};
 use std::error::Error;
 use std::net::SocketAddr;
 
@@ -40,7 +40,8 @@ pub async fn serve(
     bind_addr: impl Into<SocketAddr>,
     db_opts: PostgresOptions,
 ) -> Result<(), Box<dyn Error>> {
-    let db = PostgresDb::<PostgresTx>::connect(db_opts).await?;
+    let pool = PostgresPool::connect(db_opts).await?;
+    let db = PostgresDb::<PostgresTx>::attach(pool).await?;
     let driver = Driver::new(db);
     let app = app(driver);
 

--- a/example/src/rest/testutils.rs
+++ b/example/src/rest/testutils.rs
@@ -22,7 +22,7 @@ use crate::model::*;
 use crate::rest::app;
 use axum::Router;
 use iii_iv_core::db::{BareTx, Db};
-use iii_iv_sqlite::SqliteDb;
+use iii_iv_sqlite::{self, SqliteDb};
 
 pub(crate) struct TestContext {
     db: SqliteDb<SqliteTx>,
@@ -31,7 +31,8 @@ pub(crate) struct TestContext {
 
 impl TestContext {
     pub(crate) async fn setup() -> Self {
-        let db = SqliteDb::<SqliteTx>::connect(":memory:").await.unwrap();
+        let pool = iii_iv_sqlite::connect(":memory:").await.unwrap();
+        let db = SqliteDb::<SqliteTx>::attach(pool).await.unwrap();
         let driver = Driver::new(db.clone());
         let app = app(driver);
         Self { db, app }


### PR DESCRIPTION
In servers hosting multiple services, it is expected to have different *Tx types for each service.  When that happens, these types should all share the same database pool to minimize the number of connections.

Make this possible by separating the pool connection from the creation of the *Db type associated with a *Tx.