### PR TITLE
Fix initialization of test dbs

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -252,7 +252,8 @@ pub mod testutils {
             PostgresOptions::from_env("PGSQL_TEST").unwrap(),
             PgPoolOptions::new().min_connections(1).max_connections(1),
         );
-        let db = PostgresDb::attach(pool).await.unwrap();
+        // We don't use attach because we don't want to run the DB migration code.
+        let db = PostgresDb { pool, _phantom_tx: PhantomData::default() };
 
         let mut tx;
         let mut delay = Duration::from_millis(100 + rand::random::<u64>() % 100);

--- a/sqlite/src/lib.rs
+++ b/sqlite/src/lib.rs
@@ -143,7 +143,8 @@ pub mod testutils {
     {
         let _can_fail = env_logger::builder().is_test(true).try_init();
         let pool = connect_internal(":memory:").await.unwrap();
-        let db = SqliteDb::attach(pool).await.unwrap();
+        // We don't use attach because we don't want to run the DB migration code.
+        let db = SqliteDb { pool, _phantom_tx: PhantomData::default() };
 
         let mut tx: T = db.begin().await.unwrap();
         tx.migrate_test().await.unwrap();


### PR DESCRIPTION
The previous change caused the migration code for a Tx type to run twice during test initialization, which broke the EndBASIC Service tests because their schema does not use "IF NOT EXISTS".