### PR TITLE
Use async Mutexes

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -14,6 +14,7 @@ testutils = []
 async-trait = "0.1"
 bytes = "1.0"
 derivative = "2.2"
+futures = "0.3"
 log = "0.4"
 lru_time_cache = "0.11"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -8,12 +8,13 @@ publish = false
 
 [features]
 default = []
-testutils = []
+testutils = ["dep:futures"]
 
 [dependencies]
 async-trait = "0.1"
 axum = "0.6"
 derivative = "2.2"
+futures = { version = "0.3", optional = true }
 http = "0.2.8"
 serde_json = "1"
 thiserror = "1.0"

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -134,7 +134,8 @@ where
 #[cfg(feature = "testutils")]
 pub mod testutils {
     use super::*;
-    use std::sync::{Arc, Mutex};
+    use futures::lock::Mutex;
+    use std::sync::Arc;
 
     /// Mailer that captures outgoing messages.
     #[derive(Clone)]
@@ -146,7 +147,7 @@ pub mod testutils {
     #[async_trait]
     impl SmtpMailer for RecorderSmtpMailer {
         async fn send(&self, message: Message) -> DriverResult<()> {
-            let mut messages = self.messages.lock().unwrap();
+            let mut messages = self.messages.lock().await;
             messages.push(message);
             Ok(())
         }


### PR DESCRIPTION
All of our code is async, and the use of std::sync::Mutex was my mistake due to the lack of awareness about the existence of futures::lock::Mutex. Switch to the latter to not block threads unnecessarily.