### PR TITLE
Extend OneShotBuilder to deal with forms

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ testutils = [
     "dep:mime",
     "dep:paste",
     "dep:regex",
+    "dep:serde_urlencoded",
     "dep:tower",
 ]
 
@@ -34,6 +35,7 @@ paste = { version = "1.0", optional = true }
 regex = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_urlencoded = { version = "0.7", optional = true }
 thiserror = "1.0"
 time = "0.3"
 tower = { version = "0.4", optional = true }


### PR DESCRIPTION
This adds a new `with_query` method that extends the URI in a OneShotBuilder with a query, and a `send_form` method that sends the content of a form.

While here, also add a `with_fragment`.