### PR TITLE
Add the queue crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "example",
     "geo",
     "lettre",
+    "queue",
     "postgres",
     "sqlite",
 ]

--- a/queue/Cargo.toml
+++ b/queue/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "iii-iv-queue"
+version = "0.0.0"
+description = "III-IV: Database-backed queue for tasks"
+authors = ["Julio Merino <julio@meroh.net>"]
+edition = "2021"
+publish = false
+
+[features]
+default = ["postgres"]
+postgres = ["dep:iii-iv-postgres", "sqlx/postgres", "sqlx/time", "sqlx/uuid"]
+sqlite = ["dep:iii-iv-sqlite", "sqlx/sqlite", "sqlx/time", "sqlx/uuid"]
+testutils = []
+
+[dependencies]
+async-trait = "0.1"
+axum = "0.6"
+derivative = "2.2"
+futures = "0.3"
+iii-iv-core = { path = "../core" }
+log = "0.4"
+serde = "1"
+serde_json = "1"
+time = "0.3"
+tokio = "1"
+uuid = { version = "1.0", default-features = false, features = ["serde", "std", "v4"] }
+
+[dependencies.iii-iv-postgres]
+path = "../postgres"
+optional = true
+
+[dependencies.iii-iv-sqlite]
+path = "../sqlite"
+optional = true
+
+[dependencies.sqlx]
+version = "0.6"
+optional = true
+features = ["runtime-tokio-rustls", "time"]
+
+[dev-dependencies]
+iii-iv-core = { path = "../core", features = ["testutils"] }
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+time = { version = "0.3", features = ["formatting"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+
+[dev-dependencies.iii-iv-postgres]
+path = "../postgres"
+features = ["testutils"]
+
+[dev-dependencies.iii-iv-sqlite]
+path = "../sqlite"
+features = ["testutils"]
+
+[dev-dependencies.sqlx]
+version = "0.6"
+features = ["runtime-tokio-rustls", "sqlite", "time", "uuid"]

--- a/queue/functions/queue-loop/function.json
+++ b/queue/functions/queue-loop/function.json
@@ -1,0 +1,11 @@
+
+{
+  "bindings": [
+    {
+      "type": "timerTrigger",
+      "direction": "in",
+      "name": "req",
+      "schedule": "* */10 * * * *"
+    }
+  ]
+}

--- a/queue/src/db/mod.rs
+++ b/queue/src/db/mod.rs
@@ -1,0 +1,116 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Database abstractions to manipulate queue tasks.
+
+use crate::model::{RunnableTask, RunningTask, TaskResult};
+use async_trait::async_trait;
+use iii_iv_core::db::{BareTx, DbError, DbResult};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::time::Duration;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+mod status;
+
+#[cfg(feature = "postgres")]
+mod postgres;
+#[cfg(feature = "postgres")]
+pub use postgres::{PostgresClientTx, PostgresWorkerTx};
+
+#[cfg(any(feature = "sqlite", test))]
+mod sqlite;
+#[cfg(any(feature = "sqlite", test))]
+pub use sqlite::{SqliteClientTx, SqliteWorkerTx};
+
+#[cfg(test)]
+mod tests;
+
+/// A transaction type to enqueue tasks and query their status.
+#[async_trait]
+pub trait ClientTx: BareTx {
+    /// The task descriptors that this queue can store.
+    type T: Send + Sync + Serialize;
+
+    /// Stores a new task with a serialized `task` descriptor, marks it as runnable, and
+    /// tracks that it was enqueue at the `created` timestamp.  Returns the ID of the created
+    /// task.
+    async fn put_new_task(&mut self, task: &Self::T, created: OffsetDateTime) -> DbResult<Uuid>;
+
+    /// Fetches the result of task `id` if it has completed, or `None` otherwise.
+    async fn get_result(&mut self, id: Uuid) -> DbResult<Option<TaskResult>>;
+
+    /// Fetches all completed task results since the specified time, ordered by oldest completed
+    /// task first.
+    async fn get_results_since(
+        &mut self,
+        since: OffsetDateTime,
+    ) -> DbResult<Vec<(Uuid, TaskResult)>>;
+}
+
+/// A transaction type to process tasks from the queue.
+#[async_trait]
+pub trait WorkerTx: BareTx {
+    /// The task descriptors that this queue can process.
+    type T: Send + Sync + DeserializeOwned;
+
+    /// Gets the oldest (by last created/updated time) `limit` tasks that can be processed.
+    ///
+    /// This includes idle tasks (those that never started) and lost tasks (those that already
+    /// attempted to run but for which we have no completion report at time `now` after
+    /// `max_runtime` since the task reported a status).
+    async fn get_runnable_tasks(
+        &mut self,
+        limit: u16,
+        max_runtime: Duration,
+        now: OffsetDateTime,
+    ) -> DbResult<Vec<RunnableTask<Self::T>>>;
+
+    /// Marks the already-stored `task` as running and returns a handle to run the task.
+    ///
+    /// The task's `updated` timestamp must represent the current time, as this will be later
+    /// used to identify lost tasks.
+    ///
+    /// Note that the task must be considered runnable, either by being new or by having
+    /// exceeded its `max_runtime`.  This is to prevent executing the same task more than once
+    /// concurrently.
+    async fn set_task_running(
+        &mut self,
+        task: RunnableTask<Self::T>,
+        max_runtime: Duration,
+        updated: OffsetDateTime,
+    ) -> DbResult<RunningTask<Self::T>>;
+
+    /// Marks the already-stored task `id` as completed with the given `result`.
+    ///
+    /// The task's `updated` timestamp should represent the current time, as it will help
+    /// troubleshoot issues after completion.
+    async fn set_task_result(
+        &mut self,
+        id: Uuid,
+        result: &TaskResult,
+        updated: OffsetDateTime,
+    ) -> DbResult<()>;
+}
+
+/// Validates that an `UPDATE` statement for a task `id` only touched 1 row.
+fn ensure_one_update(id: Uuid, affected: u64) -> DbResult<()> {
+    match affected {
+        0 => Err(DbError::BackendError(format!("Task {} not found or already running/done", id))),
+        1 => Ok(()),
+        _ => Err(DbError::BackendError(format!("Update of {} affected {} rows", id, affected))),
+    }
+}

--- a/queue/src/db/postgres.rs
+++ b/queue/src/db/postgres.rs
@@ -1,0 +1,321 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Implementation of the database abstractions using PostgreSQL.
+
+use crate::db::status::{result_to_status, status_to_result, TaskStatus};
+use crate::db::{ensure_one_update, ClientTx, WorkerTx};
+use crate::model::{RunnableTask, RunningTask, TaskResult};
+use futures::TryStreamExt;
+use iii_iv_core::db::{BareTx, DbError, DbResult};
+use iii_iv_postgres::{map_sqlx_error, run_schema};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sqlx::{Postgres, Row, Transaction};
+use std::marker::PhantomData;
+use std::time::Duration;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Schema to use to initialize the database.
+const SCHEMA: &str = include_str!("postgres_schema.sql");
+
+/// A queue client transaction backed by a PostgreSQL database.
+pub struct PostgresClientTx<T: Send + Sync + Serialize> {
+    /// The PostgreSQL transaction itself.
+    tx: Transaction<'static, Postgres>,
+
+    /// Marker for the task type.
+    _data: PhantomData<T>,
+}
+
+impl<T: Send + Sync + Serialize> From<Transaction<'static, Postgres>> for PostgresClientTx<T> {
+    fn from(tx: Transaction<'static, Postgres>) -> Self {
+        Self { tx, _data: PhantomData }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + Serialize> BareTx for PostgresClientTx<T> {
+    async fn commit(mut self) -> DbResult<()> {
+        self.tx.commit().await.map_err(map_sqlx_error)
+    }
+
+    async fn migrate(&mut self) -> DbResult<()> {
+        run_schema(&mut self.tx, SCHEMA).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + Serialize> ClientTx for PostgresClientTx<T> {
+    type T = T;
+
+    async fn put_new_task(&mut self, task: &Self::T, created: OffsetDateTime) -> DbResult<Uuid> {
+        let id = Uuid::new_v4();
+
+        let json_task = match serde_json::to_string(task) {
+            Ok(json) => json,
+            Err(e) => {
+                return Err(DbError::BackendError(format!(
+                    "Cannot serialize task for storage: {}",
+                    e
+                )))
+            }
+        };
+
+        let query_str = "INSERT INTO tasks VALUES ($1, $2, $3, NULL, 0, $4, $4)";
+        let done = sqlx::query(query_str)
+            .bind(id)
+            .bind(&json_task)
+            .bind(TaskStatus::Runnable as i16)
+            .bind(created)
+            .execute(&mut self.tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        if done.rows_affected() != 1 {
+            return Err(DbError::BackendError(format!(
+                "Insert created {} rows",
+                done.rows_affected()
+            )));
+        }
+        Ok(id)
+    }
+
+    async fn get_result(&mut self, id: Uuid) -> DbResult<Option<TaskResult>> {
+        let query_str = "
+            SELECT status_code, status_reason
+            FROM tasks
+            WHERE id = $1 AND status_code != $2
+        ";
+        match sqlx::query(query_str)
+            .bind(id)
+            .bind(TaskStatus::Runnable as i16)
+            .fetch_optional(&mut self.tx)
+            .await
+            .map_err(map_sqlx_error)?
+        {
+            Some(row) => {
+                let code: i16 = row.try_get("status_code").map_err(map_sqlx_error)?;
+                let reason: Option<String> =
+                    row.try_get("status_reason").map_err(map_sqlx_error)?;
+
+                let code = match i8::try_from(code) {
+                    Ok(code) => code,
+                    Err(e) => {
+                        return Err(DbError::DataIntegrityError(format!(
+                            "Invalid status_code {}: {}",
+                            code, e
+                        )))
+                    }
+                };
+
+                let result = status_to_result(id, code, reason)?
+                    .expect("Must not have queried runnable tasks");
+                Ok(Some(result))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_results_since(
+        &mut self,
+        since: OffsetDateTime,
+    ) -> DbResult<Vec<(Uuid, TaskResult)>> {
+        let query_str = "
+            SELECT id, status_code, status_reason
+            FROM tasks
+            WHERE status_code != $1 AND updated >= $2
+            ORDER BY updated ASC
+        ";
+        let mut rows = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i16)
+            .bind(since)
+            .fetch(&mut self.tx);
+
+        let mut results = vec![];
+        while let Some(row) = rows.try_next().await.map_err(map_sqlx_error)? {
+            let id: Uuid = row.try_get("id").map_err(map_sqlx_error)?;
+            let code: i16 = row.try_get("status_code").map_err(map_sqlx_error)?;
+            let reason: Option<String> = row.try_get("status_reason").map_err(map_sqlx_error)?;
+
+            let code = match i8::try_from(code) {
+                Ok(code) => code,
+                Err(e) => {
+                    return Err(DbError::DataIntegrityError(format!(
+                        "Invalid status_code {}: {}",
+                        code, e
+                    )))
+                }
+            };
+
+            let result =
+                status_to_result(id, code, reason)?.expect("Must not have queried runnable tasks");
+            results.push((id, result));
+        }
+        Ok(results)
+    }
+}
+
+/// A queue worker transaction backed by a PostgreSQL database.
+pub struct PostgresWorkerTx<T: Send + Sync + DeserializeOwned> {
+    /// The PostgreSQL transaction itself.
+    tx: Transaction<'static, Postgres>,
+
+    /// Marker for the task type.
+    _data: PhantomData<T>,
+}
+
+impl<T: Send + Sync + DeserializeOwned> From<Transaction<'static, Postgres>>
+    for PostgresWorkerTx<T>
+{
+    fn from(tx: Transaction<'static, Postgres>) -> Self {
+        Self { tx, _data: PhantomData }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + DeserializeOwned> BareTx for PostgresWorkerTx<T> {
+    async fn commit(mut self) -> DbResult<()> {
+        self.tx.commit().await.map_err(map_sqlx_error)
+    }
+
+    async fn migrate(&mut self) -> DbResult<()> {
+        run_schema(&mut self.tx, SCHEMA).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + DeserializeOwned> WorkerTx for PostgresWorkerTx<T> {
+    type T = T;
+
+    async fn get_runnable_tasks(
+        &mut self,
+        limit: u16,
+        max_runtime: Duration,
+        now: OffsetDateTime,
+    ) -> DbResult<Vec<RunnableTask<Self::T>>> {
+        let query_str = "
+            SELECT id, json, runs
+            FROM tasks
+            WHERE
+                status_code = $1
+                AND (runs = 0 OR updated + $2 < $3)
+            ORDER BY updated ASC
+            LIMIT $4
+        ";
+        let mut rows = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i16)
+            .bind(max_runtime)
+            .bind(now)
+            .bind(i32::from(limit))
+            .fetch(&mut self.tx);
+
+        let mut tasks = vec![];
+        while let Some(row) = rows.try_next().await.map_err(map_sqlx_error)? {
+            let id: Uuid = row.try_get("id").map_err(map_sqlx_error)?;
+            let json: String = row.try_get("json").map_err(map_sqlx_error)?;
+            let runs: i16 = row.try_get("runs").map_err(map_sqlx_error)?;
+
+            let task = serde_json::from_str::<T>(&json);
+            let runs = match u8::try_from(runs) {
+                Ok(runs) => runs,
+                Err(e) => {
+                    return Err(DbError::DataIntegrityError(format!(
+                        "Invalid runs {}: {}",
+                        runs, e
+                    )))
+                }
+            };
+
+            tasks.push(RunnableTask::new(id, task, runs));
+        }
+        Ok(tasks)
+    }
+
+    async fn set_task_running(
+        &mut self,
+        task: RunnableTask<Self::T>,
+        max_runtime: Duration,
+        updated: OffsetDateTime,
+    ) -> DbResult<RunningTask<Self::T>> {
+        let task = task.try_run();
+
+        let query_str = "
+            UPDATE tasks
+            SET status_code = $1, updated = $2, runs = $3
+            WHERE
+                id = $4
+                AND status_code = $1
+                AND (runs = 0 OR updated + $5 < $2)
+        ";
+        let done = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i16)
+            .bind(updated)
+            .bind(i16::from(task.runs()))
+            .bind(task.id())
+            .bind(max_runtime)
+            .execute(&mut self.tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        ensure_one_update(task.id(), done.rows_affected())?;
+
+        Ok(task)
+    }
+
+    async fn set_task_result(
+        &mut self,
+        id: Uuid,
+        result: &TaskResult,
+        updated: OffsetDateTime,
+    ) -> DbResult<()> {
+        let (status, reason) = result_to_status(result);
+
+        let query_str = "
+            UPDATE tasks
+            SET status_code = $1, status_reason = $2, updated = $3
+            WHERE id = $4
+        ";
+        let done = sqlx::query(query_str)
+            .bind(status as i16)
+            .bind(reason)
+            .bind(updated)
+            .bind(id)
+            .execute(&mut self.tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        ensure_one_update(id, done.rows_affected())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::tests::{generate_db_tests, MockTask};
+    use iii_iv_postgres::PostgresDb;
+
+    async fn setup(
+    ) -> (PostgresDb<PostgresClientTx<MockTask>>, PostgresDb<PostgresWorkerTx<MockTask>>) {
+        let client_db = iii_iv_postgres::testutils::setup().await;
+        let worker_db = iii_iv_postgres::testutils::setup_attach(client_db.clone()).await;
+        (client_db, worker_db)
+    }
+
+    generate_db_tests!(
+        setup().await,
+        #[ignore = "Requires environment configuration and is expensive"]
+    );
+}

--- a/queue/src/db/postgres_schema.sql
+++ b/queue/src/db/postgres_schema.sql
@@ -1,0 +1,42 @@
+-- III-IV
+-- Copyright 2023 Julio Merino
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License.  You may obtain a copy
+-- of the License at:
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+CREATE TABLE IF NOT EXISTS tasks (
+    -- Unique identifier for this task.
+    id UUID PRIMARY KEY NOT NULL,
+
+    -- JSON-serialized contents of the task.
+    json TEXT NOT NULL,
+
+    -- Current status of the task.
+    status_code SMALLINT NOT NULL,
+
+    -- Reason explaining the current status of the task.  May be NULL depending
+    -- on the status_code.
+    status_reason TEXT,
+
+    -- Number of times the task attempted to run.
+    runs SMALLINT NOT NULL,
+
+    -- The time the task was created.  Useful for debugging purposes.
+    created TIMESTAMPTZ NOT NULL,
+
+    -- The time the task was last updated.  Must be initialized as "created" when
+    -- the task is first inserted into the queue.
+    updated TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS tasks_by_runnable_state
+    ON tasks (status_code, updated);

--- a/queue/src/db/sqlite.rs
+++ b/queue/src/db/sqlite.rs
@@ -1,0 +1,356 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Implementation of the database abstractions using SQLite.
+
+use crate::db::status::{result_to_status, status_to_result, TaskStatus};
+use crate::db::{ensure_one_update, ClientTx, WorkerTx};
+use crate::model::{RunnableTask, RunningTask, TaskResult};
+use futures::lock::Mutex;
+use futures::TryStreamExt;
+use iii_iv_core::db::{BareTx, DbError, DbResult};
+use iii_iv_sqlite::{map_sqlx_error, run_schema, unpack_duration, unpack_timestamp};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sqlx::{Row, Sqlite, Transaction};
+use std::marker::PhantomData;
+use std::time::Duration;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Schema to use to initialize the test database.
+const SCHEMA: &str = include_str!("sqlite_schema.sql");
+
+/// Converts an unpacked `OffsetDateTime` expressed as `sec`/`nsec` into milliseconds.
+///
+/// This ensures that the given quantities do not require sub-millisecond precision because
+/// our queries do not support that.
+///
+/// The `field` name is only used for error-logging purposes.
+fn as_msec(field: &str, sec: i64, nsec: i64) -> DbResult<i64> {
+    if nsec % 1000000 != 0 {
+        return Err(DbError::BackendError(format!(
+            "Cannot handle sub-millisecond precision in '{}': sec={}, nsec={}",
+            field, sec, nsec
+        )));
+    }
+    Ok(sec * 1000 + nsec / 1000000)
+}
+
+/// A queue client transaction backed by a SQLite database.
+pub struct SqliteClientTx<T: Send + Sync + Serialize> {
+    /// Inner transaction type to obtain access to the raw sqlx transaction.
+    tx: Mutex<Transaction<'static, Sqlite>>,
+
+    /// Marker for the task type.
+    _data: PhantomData<T>,
+}
+
+impl<T: Send + Sync + Serialize> From<Mutex<Transaction<'static, Sqlite>>> for SqliteClientTx<T> {
+    fn from(tx: Mutex<Transaction<'static, Sqlite>>) -> Self {
+        Self { tx, _data: PhantomData }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + Serialize> BareTx for SqliteClientTx<T> {
+    async fn commit(mut self) -> DbResult<()> {
+        let tx = self.tx.into_inner();
+        tx.commit().await.map_err(map_sqlx_error)
+    }
+
+    async fn migrate(&mut self) -> DbResult<()> {
+        run_schema(&mut self.tx, SCHEMA).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + Serialize> ClientTx for SqliteClientTx<T> {
+    type T = T;
+
+    async fn put_new_task(&mut self, task: &Self::T, created: OffsetDateTime) -> DbResult<Uuid> {
+        let mut tx = self.tx.lock().await;
+
+        let id = Uuid::new_v4();
+        let (created_sec, created_nsec) = unpack_timestamp(created);
+
+        let json_task = match serde_json::to_string(task) {
+            Ok(json) => json,
+            Err(e) => {
+                return Err(DbError::BackendError(format!(
+                    "Cannot serialize task for storage: {}",
+                    e
+                )))
+            }
+        };
+
+        let query_str = "INSERT INTO tasks VALUES (?, ?, ?, NULL, 0, ?, ?, ?, ?)";
+        let done = sqlx::query(query_str)
+            .bind(id)
+            .bind(&json_task)
+            .bind(TaskStatus::Runnable as i8)
+            .bind(created_sec)
+            .bind(created_nsec)
+            .bind(created_sec) // updated_sec
+            .bind(created_nsec) // updated_nsec
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        if done.rows_affected() != 1 {
+            return Err(DbError::BackendError(format!(
+                "Insert created {} rows",
+                done.rows_affected()
+            )));
+        }
+        Ok(id)
+    }
+
+    async fn get_result(&mut self, id: Uuid) -> DbResult<Option<TaskResult>> {
+        let mut tx = self.tx.lock().await;
+
+        let query_str = "
+            SELECT status_code, status_reason
+            FROM tasks
+            WHERE id = ? AND status_code != ?
+        ";
+        match sqlx::query(query_str)
+            .bind(id)
+            .bind(TaskStatus::Runnable as i8)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?
+        {
+            Some(row) => {
+                let code: i8 = row.try_get("status_code").map_err(map_sqlx_error)?;
+                let reason: Option<String> =
+                    row.try_get("status_reason").map_err(map_sqlx_error)?;
+
+                let result = status_to_result(id, code, reason)?
+                    .expect("Must not have queried runnable tasks");
+                Ok(Some(result))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_results_since(
+        &mut self,
+        since: OffsetDateTime,
+    ) -> DbResult<Vec<(Uuid, TaskResult)>> {
+        let mut tx = self.tx.lock().await;
+
+        let (since_sec, since_nsec) = unpack_timestamp(since);
+
+        let query_str = "
+            SELECT id, status_code, status_reason
+            FROM tasks
+            WHERE
+                status_code != ?
+                AND (updated_sec >= ? OR (updated_sec = ? AND updated_nsec >= ?))
+            ORDER BY updated_sec ASC, updated_nsec ASC
+        ";
+        let mut rows = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i8)
+            .bind(since_sec)
+            .bind(since_sec)
+            .bind(since_nsec)
+            .fetch(&mut *tx);
+
+        let mut results = vec![];
+        while let Some(row) = rows.try_next().await.map_err(map_sqlx_error)? {
+            let id: Uuid = row.try_get("id").map_err(map_sqlx_error)?;
+            let code: i8 = row.try_get("status_code").map_err(map_sqlx_error)?;
+            let reason: Option<String> = row.try_get("status_reason").map_err(map_sqlx_error)?;
+
+            let result =
+                status_to_result(id, code, reason)?.expect("Must not have queried runnable tasks");
+            results.push((id, result));
+        }
+        Ok(results)
+    }
+}
+
+/// A queue worker transaction backed by a SQLite database.
+pub struct SqliteWorkerTx<T: Send + Sync + DeserializeOwned> {
+    /// Inner transaction type to obtain access to the raw sqlx transaction.
+    tx: Mutex<Transaction<'static, Sqlite>>,
+
+    /// Marker for the task type.
+    _data: PhantomData<T>,
+}
+
+impl<T: Send + Sync + DeserializeOwned> From<Mutex<Transaction<'static, Sqlite>>>
+    for SqliteWorkerTx<T>
+{
+    fn from(tx: Mutex<Transaction<'static, Sqlite>>) -> Self {
+        Self { tx, _data: PhantomData }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + DeserializeOwned> BareTx for SqliteWorkerTx<T> {
+    async fn commit(mut self) -> DbResult<()> {
+        let tx = self.tx.into_inner();
+        tx.commit().await.map_err(map_sqlx_error)
+    }
+
+    async fn migrate(&mut self) -> DbResult<()> {
+        run_schema(&mut self.tx, SCHEMA).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Send + Sync + DeserializeOwned> WorkerTx for SqliteWorkerTx<T> {
+    type T = T;
+
+    async fn get_runnable_tasks(
+        &mut self,
+        limit: u16,
+        max_runtime: Duration,
+        now: OffsetDateTime,
+    ) -> DbResult<Vec<RunnableTask<Self::T>>> {
+        let mut tx = self.tx.lock().await;
+
+        let max_runtime_msec = {
+            let (max_runtime_sec, max_runtime_nsec) = unpack_duration(max_runtime);
+            as_msec("max_runtime", max_runtime_sec, max_runtime_nsec)?
+        };
+
+        let now_msec = {
+            let (now_sec, now_nsec) = unpack_timestamp(now);
+            as_msec("now", now_sec, now_nsec)?
+        };
+
+        let query_str = "
+            SELECT
+                id, json, runs,
+                updated_sec * 1000 + updated_nsec / 1000000 AS updated_msec
+            FROM tasks
+            WHERE status_code = ? AND (runs = 0 OR updated_msec + ? < ?)
+            ORDER BY updated_sec ASC, updated_nsec ASC
+            LIMIT ?
+        ";
+        let mut rows = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i8)
+            .bind(max_runtime_msec)
+            .bind(now_msec)
+            .bind(i32::from(limit))
+            .fetch(&mut *tx);
+
+        let mut tasks = vec![];
+        while let Some(row) = rows.try_next().await.map_err(map_sqlx_error)? {
+            let id: Uuid = row.try_get("id").map_err(map_sqlx_error)?;
+            let json: String = row.try_get("json").map_err(map_sqlx_error)?;
+            let runs: i8 = row.try_get("runs").map_err(map_sqlx_error)?;
+
+            let task = serde_json::from_str::<T>(&json);
+            let runs = runs as u8;
+
+            tasks.push(RunnableTask::new(id, task, runs));
+        }
+        Ok(tasks)
+    }
+
+    async fn set_task_running(
+        &mut self,
+        task: RunnableTask<Self::T>,
+        max_runtime: Duration,
+        updated: OffsetDateTime,
+    ) -> DbResult<RunningTask<Self::T>> {
+        let mut tx = self.tx.lock().await;
+
+        let max_runtime_msec = {
+            let (max_runtime_sec, max_runtime_nsec) = unpack_duration(max_runtime);
+            as_msec("max_runtime", max_runtime_sec, max_runtime_nsec)?
+        };
+
+        let (updated_sec, updated_nsec) = unpack_timestamp(updated);
+        let updated_msec = as_msec("updated", updated_sec, updated_nsec)?;
+
+        let task = task.try_run();
+
+        let query_str = "
+            UPDATE tasks
+            SET status_code = ?, updated_sec = ?, updated_nsec = ?, runs = ?
+            WHERE
+                id = ?
+                AND status_code = ?
+                AND (
+                    runs = 0
+                    OR (updated_sec * 1000 + updated_nsec / 1000000) + ? < ?
+                )
+        ";
+        let done = sqlx::query(query_str)
+            .bind(TaskStatus::Runnable as i8)
+            .bind(updated_sec)
+            .bind(updated_nsec)
+            .bind(task.runs() as i8)
+            .bind(task.id())
+            .bind(TaskStatus::Runnable as i8)
+            .bind(max_runtime_msec)
+            .bind(updated_msec)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        ensure_one_update(task.id(), done.rows_affected())?;
+
+        Ok(task)
+    }
+
+    async fn set_task_result(
+        &mut self,
+        id: Uuid,
+        result: &TaskResult,
+        updated: OffsetDateTime,
+    ) -> DbResult<()> {
+        let mut tx = self.tx.lock().await;
+
+        let (status, reason) = result_to_status(result);
+        let (updated_sec, updated_nsec) = unpack_timestamp(updated);
+
+        let query_str = "
+            UPDATE tasks
+            SET status_code = ?, status_reason = ?, updated_sec = ?, updated_nsec = ?
+            WHERE id = ?
+        ";
+        let done = sqlx::query(query_str)
+            .bind(status as i8)
+            .bind(reason)
+            .bind(updated_sec)
+            .bind(updated_nsec)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_sqlx_error)?;
+        ensure_one_update(id, done.rows_affected())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::tests::{generate_db_tests, MockTask};
+    use iii_iv_sqlite::SqliteDb;
+
+    async fn setup() -> (SqliteDb<SqliteClientTx<MockTask>>, SqliteDb<SqliteWorkerTx<MockTask>>) {
+        let client_db = iii_iv_sqlite::testutils::setup().await;
+        let worker_db = iii_iv_sqlite::testutils::setup_attach(client_db.clone()).await;
+        (client_db, worker_db)
+    }
+
+    generate_db_tests!(setup().await);
+}

--- a/queue/src/db/sqlite_schema.sql
+++ b/queue/src/db/sqlite_schema.sql
@@ -1,0 +1,46 @@
+-- III-IV
+-- Copyright 2023 Julio Merino
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License.  You may obtain a copy
+-- of the License at:
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    -- Unique identifier for this task.
+    id UUID PRIMARY KEY NOT NULL,
+
+    -- JSON-serialized contents of the task.
+    json TEXT NOT NULL,
+
+    -- Current status of the task.
+    status_code INTEGER NOT NULL,
+
+    -- Reason explaining the current status of the task.  May be NULL depending
+    -- on the status_code.
+    status_reason TEXT,
+
+    -- Number of times the task attempted to run.
+    runs INTEGER NOT NULL,
+
+    -- The time the task was created.  Useful for debugging purposes.
+    created_sec INTEGER NOT NULL,
+    created_nsec INTEGER NOT NULL,
+
+    -- The time the task was last updated.  Must be initialized as "created" when
+    -- the task is first inserted into the queue.
+    updated_sec INTEGER NOT NULL,
+    updated_nsec INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS tasks_by_runnable_state
+    ON tasks (status_code, updated_sec, updated_nsec);

--- a/queue/src/db/status.rs
+++ b/queue/src/db/status.rs
@@ -1,0 +1,165 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Conversions between `TaskResult`s and their persisted representation.
+
+use crate::model::TaskResult;
+use iii_iv_core::db::{DbError, DbResult};
+use uuid::Uuid;
+
+/// Task status as stored in the database.
+#[derive(Debug, Eq, PartialEq)]
+#[repr(i8)]
+pub(super) enum TaskStatus {
+    /// The task is either new or running.
+    ///
+    /// The `runs` field of the task can be used to distinguish between the two statuses.
+    ///
+    /// Even though a task may be marked as runnable, it should only be attempted to run if
+    /// either it is new (`runs == 0`) or if can be declared as lost (its `updated` timestamp
+    /// is older than the maximum allowed runtime for the task).
+    Runnable = 1,
+
+    /// The task completed successfully.  The `reason` will not be present.
+    Done = 2,
+
+    /// The task failed and the reason for the failure is in `reason`.
+    Failed = 3,
+
+    /// The task was abandoned and the reason for the failure is in `reason`.
+    Abandoned = 4,
+}
+
+/// Converts a task result into the status code and reason to be stored into the database.
+pub(super) fn result_to_status(result: &TaskResult) -> (TaskStatus, Option<&str>) {
+    match result {
+        TaskResult::Done => (TaskStatus::Done, None),
+        TaskResult::Failed(e) => (TaskStatus::Failed, Some(e)),
+        TaskResult::Abandoned(e) => (TaskStatus::Abandoned, Some(e)),
+    }
+}
+
+/// Parses a status `code`/`reason` pair as extracted from the database into a `TaskResult`.
+///
+/// If the task is still running, there is no result yet.
+///
+/// The `id` is used for error reporting reasons only.
+pub(super) fn status_to_result(
+    id: Uuid,
+    code: i8,
+    reason: Option<String>,
+) -> DbResult<Option<TaskResult>> {
+    match code {
+        x if x == (TaskStatus::Runnable as i8) => Ok(None),
+
+        x if x == (TaskStatus::Done as i8) => match reason {
+            None => Ok(Some(TaskResult::Done)),
+            Some(_) => Err(DbError::DataIntegrityError(format!(
+                "Task {} is Done but status_reason is not empty",
+                id
+            ))),
+        },
+
+        x if x == (TaskStatus::Failed as i8) => match reason {
+            None => Err(DbError::DataIntegrityError(format!(
+                "Task {} is Failed but status_reason is missing",
+                id
+            ))),
+            Some(reason) => Ok(Some(TaskResult::Failed(reason))),
+        },
+
+        x if x == (TaskStatus::Abandoned as i8) => match reason {
+            None => Err(DbError::DataIntegrityError(format!(
+                "Task {} is Abandoned but status_reason is missing",
+                id
+            ))),
+            Some(reason) => Ok(Some(TaskResult::Abandoned(reason))),
+        },
+
+        x => Err(DbError::DataIntegrityError(format!("Task {} code {} is unknown", id, x))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_result_to_status() {
+        assert_eq!((TaskStatus::Done, None), result_to_status(&TaskResult::Done));
+
+        assert_eq!(
+            (TaskStatus::Failed, Some("foo")),
+            result_to_status(&TaskResult::Failed("foo".to_owned()))
+        );
+
+        assert_eq!(
+            (TaskStatus::Abandoned, Some("foo")),
+            result_to_status(&TaskResult::Abandoned("foo".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_status_to_result_runnable_is_none() {
+        match status_to_result(Uuid::new_v4(), TaskStatus::Runnable as i8, None) {
+            Ok(None) => (),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+
+        match status_to_result(Uuid::new_v4(), TaskStatus::Runnable as i8, Some("foo".to_owned())) {
+            Ok(None) => (),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+    }
+
+    #[test]
+    fn test_status_to_result_failed_must_have_reason() {
+        assert_eq!(
+            Ok(Some(TaskResult::Failed("msg".to_owned()))),
+            status_to_result(Uuid::new_v4(), TaskStatus::Failed as i8, Some("msg".to_owned()))
+        );
+
+        match status_to_result(Uuid::new_v4(), TaskStatus::Failed as i8, None) {
+            Err(DbError::DataIntegrityError(_)) => (),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+    }
+
+    #[test]
+    fn test_status_to_result_abandoned_must_have_reason() {
+        assert_eq!(
+            Ok(Some(TaskResult::Abandoned("msg".to_owned()))),
+            status_to_result(Uuid::new_v4(), TaskStatus::Abandoned as i8, Some("msg".to_owned()))
+        );
+
+        match status_to_result(Uuid::new_v4(), TaskStatus::Abandoned as i8, None) {
+            Err(DbError::DataIntegrityError(_)) => (),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+    }
+
+    #[test]
+    fn test_status_to_result_unknown_code() {
+        match status_to_result(Uuid::new_v4(), 123, None) {
+            Err(DbError::DataIntegrityError(e)) => assert!(e.contains("unknown")),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+
+        match status_to_result(Uuid::new_v4(), 123, Some("foo".to_owned())) {
+            Err(DbError::DataIntegrityError(e)) => assert!(e.contains("unknown")),
+            r => panic!("Unexpected result: {:?}", r),
+        }
+    }
+}

--- a/queue/src/db/tests.rs
+++ b/queue/src/db/tests.rs
@@ -1,0 +1,590 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Common tests for any database implementation.
+
+use crate::db::{ClientTx, WorkerTx};
+use crate::model::{RunnableTask, TaskResult};
+use iii_iv_core::db::{BareTx, Db, DbError};
+use serde::de::{self, Visitor};
+use serde::ser::{self, SerializeStruct};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use time::{macros::datetime, OffsetDateTime};
+use uuid::Uuid;
+
+/// A trivial task to validate (de)serialization behavior.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub(super) struct MockTask {
+    /// The "payload" for the task.
+    ///
+    /// In most cases, the value is irrelevant but can be used to validate that we are getting the
+    /// specific task we expect from the database.
+    ///
+    /// The magic `TRIGGER_SER_ERROR` and `TRIGGER_DE_ERROR` values can be used to enqueue failures
+    /// during JSON (de)serialization.
+    #[serde(deserialize_with = "crate::db::tests::deserialize_i")]
+    i: u32,
+}
+
+impl MockTask {
+    /// Causes serialization to fail.
+    const TRIGGER_SER_ERROR: u32 = 12345;
+
+    /// Causes deserialization to fail.
+    const TRIGGER_DE_ERROR: u32 = 54321;
+}
+
+impl Serialize for MockTask {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.i == Self::TRIGGER_SER_ERROR {
+            return Err(ser::Error::custom("Custom ser error"));
+        }
+
+        let mut task = serializer.serialize_struct("MockTask", 1)?;
+        task.serialize_field("i", &self.i)?;
+        task.end()
+    }
+}
+
+/// A visitor for the `i` field of `MockTask`.
+struct IVisitor;
+
+impl<'de> Visitor<'de> for IVisitor {
+    type Value = u32;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str(r#"a u32 number"#)
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let v = u32::try_from(v).expect("Value must have fit");
+        if v == MockTask::TRIGGER_DE_ERROR {
+            return Err(de::Error::custom("Custom de error"));
+        }
+        Ok(v)
+    }
+}
+
+/// Deserializes the `i` field of `MockTask`, returning errors if requested.
+fn deserialize_i<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_u32(IVisitor)
+}
+
+/// Helper function to enqueue a new task (one that has never run yet) with a data value `i`
+/// into the database `client_db`.
+async fn put_new_task<CD>(client_db: &CD, i: u32, created: OffsetDateTime) -> Uuid
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+{
+    let task = MockTask { i };
+
+    let mut tx = client_db.begin().await.unwrap();
+    let id = tx.put_new_task(&task, created).await.unwrap();
+    tx.commit().await.unwrap();
+
+    id
+}
+
+/// Enqueues a task that is running or has finished running with a data value `i` into the
+/// database.  `runs` indicates how many runs we expect to be recorded for the task, and the
+/// optional `result` indicates whether the task has completed or not.
+///
+/// This is a helper to the `put_running_task` and `put_done_task` functions and should not be
+/// invoked directly by tests.
+async fn put_active_task<CD, WD>(
+    client_db: &CD,
+    worker_db: &WD,
+    i: u32,
+    result: Option<&TaskResult>,
+    max_runtime: Duration,
+    updated: OffsetDateTime,
+    runs: u8,
+) -> Uuid
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    assert!(runs > 0, "Running tasks must have at least one recorded run attempt");
+
+    let task = MockTask { i };
+
+    // Creation time should not matter in our queries, so set it to something far in the past.
+    let created = datetime!(1984-01-01 0:00 UTC);
+
+    let mut tx = client_db.begin().await.unwrap();
+    let id = tx.put_new_task(&task, created).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = worker_db.begin().await.unwrap();
+    tx.set_task_running(RunnableTask::new(id, Ok(task), runs - 1), max_runtime, updated)
+        .await
+        .unwrap();
+    if let Some(result) = result {
+        tx.set_task_result(id, result, updated).await.unwrap();
+    }
+    tx.commit().await.unwrap();
+
+    id
+}
+
+/// Helper function to enqueue a task that is running with a data value `i` into the database.
+/// `runs` indicates how many runs we expect to be recorded for the task.
+async fn put_running_task<CD, WD>(
+    client_db: &CD,
+    worker_db: &WD,
+    i: u32,
+    max_runtime: Duration,
+    updated: OffsetDateTime,
+    runs: u8,
+) -> Uuid
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    put_active_task(client_db, worker_db, i, None, max_runtime, updated, runs).await
+}
+
+/// Helper function to enqueue a task that has finished running with a data value `i` into the
+/// database.  `runs` indicates how many runs we expect to be recorded for the task, and `result`
+/// indicates the outcome of the task.
+async fn put_done_task<CD, WD>(
+    client_db: &CD,
+    worker_db: &WD,
+    i: u32,
+    result: &TaskResult,
+    max_runtime: Duration,
+    updated: OffsetDateTime,
+    runs: u8,
+) -> Uuid
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    put_active_task(client_db, worker_db, i, Some(result), max_runtime, updated, runs).await
+}
+
+pub(super) async fn test_put_get_runnable_all_new<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(60);
+    let now = datetime!(2023-05-17 5:47 UTC);
+
+    let id1 = put_new_task(&client_db, 3, datetime!(2023-05-17 5:40 UTC)).await;
+    let id2 = put_new_task(&client_db, 1, datetime!(2023-05-17 5:55 UTC)).await;
+    let id3 = put_new_task(&client_db, 2, datetime!(2023-05-17 5:50 UTC)).await;
+
+    let mut tx = worker_db.begin().await.unwrap();
+    let runnable = tx.get_runnable_tasks(10, max_runtime, now).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let exp_runnable = vec![
+        RunnableTask::new(id1, Ok(MockTask { i: 3 }), 0),
+        RunnableTask::new(id3, Ok(MockTask { i: 2 }), 0),
+        RunnableTask::new(id2, Ok(MockTask { i: 1 }), 0),
+    ];
+    assert_eq!(exp_runnable, runnable);
+}
+
+pub(super) async fn test_put_get_runnable_mix<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(5 * 60);
+    let now = datetime!(2023-05-18 17:10 UTC);
+
+    // Put a task with 0 reruns that's outside the max_runtime window.
+    // Must be considered as runnable.
+    let id1 = put_new_task(&client_db, 1, datetime!(2023-05-18 16:00 UTC)).await;
+
+    // Put a task with 0 reruns that's inside the max_runtime window.
+    // Must be considered as runnable.
+    let id2 = put_new_task(&client_db, 2, datetime!(2023-05-18 17:08 UTC)).await;
+
+    // Put a task with multiple reruns that's outside of the max_runtime window.
+    // Must be considered as runnable.
+    let id3 = put_running_task(
+        &client_db,
+        &worker_db,
+        3,
+        max_runtime,
+        datetime!(2023-05-18 17:04 UTC),
+        4,
+    )
+    .await;
+
+    // Put a task with multiple reruns that's inside of the max_runtime window.
+    // Must NOT be considered as runnable yet.
+    let _ = put_running_task(
+        &client_db,
+        &worker_db,
+        4,
+        max_runtime,
+        datetime!(2023-05-18 17:06 UTC),
+        5,
+    )
+    .await;
+
+    for result in
+        [TaskResult::Done, TaskResult::Failed("".to_owned()), TaskResult::Abandoned("".to_owned())]
+    {
+        // Put a few tasks that are done and that are outside of the max_runtime window.
+        // Must NOT be considered as runnable anymore.
+        put_done_task(
+            &client_db,
+            &worker_db,
+            5,
+            &result,
+            max_runtime,
+            datetime!(2023-05-18 16:10 UTC),
+            2,
+        )
+        .await;
+
+        // Put a few tasks that are done and that are inside of the max_runtime window.
+        // Must NOT be considered as runnable anymore.
+        put_done_task(
+            &client_db,
+            &worker_db,
+            6,
+            &result,
+            max_runtime,
+            datetime!(2023-05-18 17:06 UTC),
+            2,
+        )
+        .await;
+    }
+
+    let mut tx = worker_db.begin().await.unwrap();
+    let runnable = tx.get_runnable_tasks(10, max_runtime, now).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let exp_runnable = vec![
+        RunnableTask::new(id1, Ok(MockTask { i: 1 }), 0),
+        RunnableTask::new(id3, Ok(MockTask { i: 3 }), 4),
+        RunnableTask::new(id2, Ok(MockTask { i: 2 }), 0),
+    ];
+    assert_eq!(exp_runnable, runnable);
+}
+
+pub(super) async fn test_put_get_runnable_limit<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(60);
+    let now = datetime!(2023-05-19 8:00 UTC);
+
+    for _ in 0..100 {
+        let _id = put_new_task(&client_db, 0, datetime!(2023-05-19 7:15 UTC)).await;
+    }
+
+    let mut tx = worker_db.begin().await.unwrap();
+    let runnable = tx.get_runnable_tasks(10, max_runtime, now).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(10, runnable.len());
+}
+
+pub(super) async fn test_put_ser_error_aborts_put<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let now = datetime!(2023-05-19 8:30 UTC);
+
+    let mut tx = client_db.begin().await.unwrap();
+    let error = tx
+        .put_new_task(&MockTask { i: MockTask::TRIGGER_SER_ERROR }, now - Duration::from_secs(10))
+        .await
+        .unwrap_err();
+    assert!(format!("{}", error).contains("Custom ser error"));
+    tx.commit().await.unwrap();
+
+    let mut tx = worker_db.begin().await.unwrap();
+    let runnable = tx.get_runnable_tasks(10, Duration::from_secs(1), now).await.unwrap();
+    tx.commit().await.unwrap();
+    assert!(runnable.is_empty());
+}
+
+pub(super) async fn test_set_task_running_fails_if_already_running<CD, WD>(
+    (client_db, worker_db): (CD, WD),
+) where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(5 * 60);
+    let now = datetime!(2023-06-01 06:50 UTC);
+
+    let id = put_running_task(&client_db, &worker_db, 0, max_runtime, now, 1).await;
+
+    // Try to mark the task as running again before its `max_runtime` has elapsed, which must fail.
+    {
+        let mut tx = worker_db.begin().await.unwrap();
+        match tx
+            .set_task_running(
+                RunnableTask::new(id, Ok(MockTask { i: 0 }), 0),
+                max_runtime,
+                now + max_runtime,
+            )
+            .await
+        {
+            Err(DbError::BackendError(e)) => assert!(e.contains("already running")),
+            e => panic!("Expected not found error, but got: {:?}", e),
+        }
+    }
+
+    // Try to mark the task as running again after its `max_runtime` has elapsed, which must work.
+    {
+        let mut tx = worker_db.begin().await.unwrap();
+        tx.set_task_running(
+            RunnableTask::new(id, Ok(MockTask { i: 0 }), 0),
+            max_runtime,
+            now + max_runtime + Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+    }
+}
+
+pub(super) async fn test_set_task_running_fails_if_already_completed<CD, WD>(
+    (client_db, worker_db): (CD, WD),
+) where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(5 * 60);
+    let now = datetime!(2023-06-01 06:50 UTC);
+
+    for result in [
+        TaskResult::Done,
+        TaskResult::Failed("foo".to_owned()),
+        TaskResult::Abandoned("bar".to_owned()),
+    ] {
+        let id = put_done_task(&client_db, &worker_db, 0, &result, max_runtime, now, 1).await;
+
+        // Try to mark the task as running after it has already completed, which must fail.
+        let mut tx = worker_db.begin().await.unwrap();
+        match tx
+            .set_task_running(
+                RunnableTask::new(id, Ok(MockTask { i: 0 }), 0),
+                max_runtime,
+                now + max_runtime * 2,
+            )
+            .await
+        {
+            Err(DbError::BackendError(e)) => assert!(e.contains("already running/done")),
+            e => panic!("Expected not found error, but got: {:?}", e),
+        }
+    }
+}
+
+pub(super) async fn test_get_runnable_propagates_de_error<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_secs(60);
+    let now = datetime!(2023-05-17 5:47 UTC);
+
+    let id =
+        put_new_task(&client_db, MockTask::TRIGGER_DE_ERROR, datetime!(2023-05-17 5:40 UTC)).await;
+
+    let mut tx = worker_db.begin().await.unwrap();
+    let mut runnable = tx.get_runnable_tasks(10, max_runtime, now).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let task = runnable.pop().expect("Must have found exactly one task");
+    assert!(runnable.is_empty(), "Must have found exactly one task");
+
+    assert_eq!(id, task.id());
+    let task = task.try_run(); // Needed to access the underlying JSON result.
+    let error = task.into_json_task().unwrap_err();
+    assert!(format!("{}", error).contains("Custom de error"));
+}
+
+pub(super) async fn test_get_result_new<CD, WD>((client_db, _worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let id = put_new_task(&client_db, 0, datetime!(2023-05-26 14:35 UTC)).await;
+
+    let mut tx = client_db.begin().await.unwrap();
+    let result = tx.get_result(id).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(None, result);
+}
+
+pub(super) async fn test_get_result_still_running<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_millis(10);
+    let id = put_running_task(
+        &client_db,
+        &worker_db,
+        0,
+        max_runtime,
+        datetime!(2023-05-26 14:35 UTC),
+        10,
+    )
+    .await;
+
+    let mut tx = client_db.begin().await.unwrap();
+    let result = tx.get_result(id).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(None, result);
+}
+
+pub(super) async fn test_get_result_done<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let max_runtime = Duration::from_millis(10);
+    for exp_result in [
+        TaskResult::Done,
+        TaskResult::Failed("foo".to_owned()),
+        TaskResult::Abandoned("bar".to_owned()),
+    ] {
+        let id = put_done_task(
+            &client_db,
+            &worker_db,
+            0,
+            &exp_result,
+            max_runtime,
+            datetime!(2023-05-26 14:35 UTC),
+            10,
+        )
+        .await;
+
+        let mut tx = client_db.begin().await.unwrap();
+        let result = tx.get_result(id).await.unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(Some(exp_result), result);
+    }
+}
+
+pub(super) async fn test_get_results_since<CD, WD>((client_db, worker_db): (CD, WD))
+where
+    CD: Db,
+    CD::Tx: ClientTx<T = MockTask>,
+    WD: Db,
+    WD::Tx: WorkerTx<T = MockTask>,
+{
+    let since = datetime!(2023-05-19 7:30 UTC);
+    let before = since - Duration::from_secs(30);
+    let after = since + Duration::from_secs(30);
+    let max_runtime = Duration::from_millis(10);
+
+    put_new_task(&client_db, 1, before).await;
+    put_new_task(&client_db, 2, after).await;
+
+    put_running_task(&client_db, &worker_db, 3, max_runtime, before, 4).await;
+    put_running_task(&client_db, &worker_db, 4, max_runtime, after, 5).await;
+
+    let mut exp_results = vec![];
+    for (i, result) in
+        [TaskResult::Done, TaskResult::Failed("".to_owned()), TaskResult::Abandoned("".to_owned())]
+            .iter()
+            .enumerate()
+    {
+        // The results of the query are sorted by timestamp, so make sure they are stable by using
+        // different values for each task.
+        //
+        // It is important for `i` to start at 0 to assert the behavior of a task that completes at
+        // exactly `since` time.
+        let before = before + Duration::from_secs(i as u64);
+        let after = after + Duration::from_secs(i as u64);
+
+        put_done_task(&client_db, &worker_db, 0, result, max_runtime, before, 10).await;
+
+        let id = put_done_task(&client_db, &worker_db, 0, result, max_runtime, after, 10).await;
+        exp_results.push((id, result.clone()));
+    }
+
+    let mut tx = client_db.begin().await.unwrap();
+    let results = tx.get_results_since(since).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(exp_results, results);
+}
+
+macro_rules! generate_db_tests [
+    ( $setup:expr $(, #[$extra:meta] )? ) => {
+        iii_iv_core::db::testutils::generate_tests!(
+            $(#[$extra],)?
+            $setup,
+            $crate::db::tests,
+            test_put_get_runnable_all_new,
+            test_put_get_runnable_mix,
+            test_put_get_runnable_limit,
+            test_put_ser_error_aborts_put,
+            test_set_task_running_fails_if_already_running,
+            test_set_task_running_fails_if_already_completed,
+            test_get_runnable_propagates_de_error,
+            test_get_result_new,
+            test_get_result_still_running,
+            test_get_result_done,
+            test_get_results_since
+        );
+    }
+];
+
+pub(super) use generate_db_tests;

--- a/queue/src/driver/client.rs
+++ b/queue/src/driver/client.rs
@@ -1,0 +1,167 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Provides the task queue client implementation.
+
+use crate::db::ClientTx;
+use crate::driver::Worker;
+use crate::model::TaskResult;
+use derivative::Derivative;
+use futures::lock::Mutex;
+use iii_iv_core::clocks::Clock;
+use iii_iv_core::db::{BareTx, Db};
+use iii_iv_core::driver::{DriverError, DriverResult};
+use log::warn;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// The queue client.
+///
+/// This driver talks to the database to manipulate and query tasks, delegating execution to the
+/// worker process.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct Client<T, C, D>
+where
+    C: Clock + Clone + Send + Sync + 'static,
+    D: Db + Clone + Send + Sync + 'static,
+    D::Tx: ClientTx<T = T> + From<D::SqlxTx> + Send + Sync + 'static,
+    T: Send + Sync,
+{
+    /// The database that the driver uses for persistence.
+    db: D,
+
+    /// Clock instance to obtain the current time.
+    clock: C,
+
+    /// Worker to notify when a task is enqueued for immediate processing.  This is only useful
+    /// when the client and worker live in the same process, and thus is why this is optional.
+    worker: Option<Arc<Mutex<Worker<T>>>>,
+}
+
+impl<T, C, D> Client<T, C, D>
+where
+    C: Clock + Clone + Send + Sync + 'static,
+    D: Db + Clone + Send + Sync + 'static,
+    D::Tx: ClientTx<T = T> + From<D::SqlxTx> + Send + Sync + 'static,
+    T: Send + Sync,
+{
+    /// Creates a new driver backed by `db` and a `clock`, optionally poking `worker` when tasks
+    /// are enqueued.
+    pub fn new(db: D, clock: C, worker: Option<Arc<Mutex<Worker<T>>>>) -> Self {
+        Self { db, clock, worker }
+    }
+
+    /// Attempts to notify the worker, if one is configured, to ensure we make forward progress
+    /// as early as possible.  This is only an optimization, so any failures are logged and then
+    /// ignored.
+    async fn maybe_notify_worker(&mut self) {
+        if let Some(worker) = self.worker.clone() {
+            let mut worker = worker.lock().await;
+            if let Err(e) = worker.notify().await {
+                warn!("Failed to notify worker; will run later: {}", e);
+            }
+        }
+    }
+
+    /// Inserts a new `task` into the queue and returns its identifier.
+    ///
+    /// If the client is configured to notify a worker, this notifies the worker for immediate
+    /// task processing.
+    pub async fn enqueue(&mut self, task: &T) -> DriverResult<Uuid> {
+        let mut tx = self.db.begin().await?;
+        let id = tx.put_new_task(task, self.clock.now_utc()).await?;
+        tx.commit().await?;
+
+        self.maybe_notify_worker().await;
+
+        Ok(id)
+    }
+
+    /// Returns the result of task `id` if it is already available.
+    pub async fn poll(&mut self, id: Uuid) -> DriverResult<Option<TaskResult>> {
+        let mut tx = self.db.begin().await?;
+        let result = tx.get_result(id).await?;
+        tx.commit().await?;
+        Ok(result)
+    }
+
+    /// Waits for task `id` until it has completed execution by polling its state every `period`.
+    pub async fn wait(&mut self, id: Uuid, period: Duration) -> DriverResult<TaskResult> {
+        loop {
+            if let Some(result) = self.poll(id).await? {
+                break Ok(result);
+            }
+
+            self.maybe_notify_worker().await;
+
+            tokio::time::sleep(period).await;
+        }
+    }
+
+    /// Waits until all tasks specified in `ids` have completed execution by polling their state
+    /// every `period`.  Only tasks with a result produced at or after `since` are considered.
+    pub async fn wait_all(
+        &mut self,
+        ids: &[Uuid],
+        mut since: OffsetDateTime,
+        period: Duration,
+    ) -> DriverResult<HashMap<Uuid, TaskResult>> {
+        let mut ids = {
+            let mut set: HashSet<Uuid> = HashSet::default();
+            for id in ids {
+                set.insert(*id);
+            }
+            set
+        };
+
+        let mut results = HashMap::default();
+        while !ids.is_empty() {
+            let partial = {
+                let mut tx = self.db.begin().await?;
+                let results = tx.get_results_since(since).await?;
+                tx.commit().await?;
+                results
+            };
+
+            for (id, result) in partial {
+                if !ids.remove(&id) {
+                    // Ignore this result given that the caller didn't ask for it.
+                    continue;
+                }
+
+                let previous = results.insert(id, result);
+                if previous.is_some() {
+                    // If this happens, we have a bug in the queue implementation because we
+                    // somehow reran a task after it completed.  We must handle this gracefully
+                    // given that we are dealing with persisted state, we cannot simply assert.
+                    return Err(DriverError::BackendError(format!(
+                        "Got a result for task {} twice",
+                        id
+                    )));
+                }
+            }
+
+            self.maybe_notify_worker().await;
+
+            since += period;
+            tokio::time::sleep(period).await;
+        }
+        Ok(results)
+    }
+}

--- a/queue/src/driver/mod.rs
+++ b/queue/src/driver/mod.rs
@@ -1,0 +1,288 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Provides the task queue client and worker implementations.
+
+mod client;
+pub use client::Client;
+
+mod worker;
+pub use worker::{Worker, WorkerOptions};
+
+#[cfg(test)]
+mod testutils {
+    use super::*;
+    use crate::db::{SqliteClientTx, SqliteWorkerTx};
+    use crate::model::{ExecError, ExecResult};
+    use futures::lock::Mutex;
+    use iii_iv_core::clocks::testutils::MonotonicClock;
+    use iii_iv_sqlite::SqliteDb;
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// A task definition for testing purposes.
+    #[derive(Deserialize, Serialize)]
+    pub(super) struct MockTask {
+        /// The domain-specific identifier of the task.
+        pub(super) id: u16,
+
+        /// What the task will return upon execution.
+        pub(super) result: Result<(), String>,
+
+        /// Number of times to crash before succeeding.
+        pub(super) crash: u16,
+    }
+
+    /// Mutable state for one task.
+    #[derive(Default)]
+    pub(super) struct TaskState {
+        /// Number of times the task has attempted to run so far.
+        pub(super) runs: u16,
+
+        /// Whether the task completed successfully and returned its stored result.
+        pub(super) done: bool,
+    }
+
+    /// Mutable state for all tasks keyed by `MockTask::id`.
+    type TaskStateById = Arc<Mutex<HashMap<u16, TaskState>>>;
+
+    /// Executes `task`, updating `state` with details for validation.
+    async fn run_task(task: MockTask, state_by_id: TaskStateById) -> ExecResult {
+        let mut state_by_id = state_by_id.lock().await;
+        let mut state = state_by_id.entry(task.id).or_insert_with(TaskState::default);
+
+        state.runs += 1;
+
+        if state.runs <= task.crash {
+            return Err(ExecError::SimulatedCrash);
+        }
+
+        assert!(!state.done, "Task {} completed twice", task.id);
+        state.done = true;
+
+        task.result.map_err(ExecError::Failed)
+    }
+
+    /// State of a running test.
+    pub(super) struct TestContext {
+        /// The client used to enqueue and poll for tasks.
+        pub(super) client: Client<MockTask, MonotonicClock, SqliteDb<SqliteClientTx<MockTask>>>,
+
+        /// The workers to execute the tasks with a test-supplied function.
+        pub(super) workers: Vec<Arc<Mutex<Worker<MockTask>>>>,
+
+        /// The clock used to track task state changes.
+        pub(super) clock: MonotonicClock,
+
+        /// The shared task state updated by task execution for all tasks.
+        pub(super) state: TaskStateById,
+    }
+
+    impl TestContext {
+        /// Initializes an in-memory queue with one in-process worker and a client that is
+        /// configured to poke the worker when new tasks are enqueued.
+        pub(super) async fn setup_one_connected(opts: WorkerOptions) -> Self {
+            let client_db = iii_iv_sqlite::testutils::setup().await;
+            let worker_db: SqliteDb<SqliteWorkerTx<MockTask>> =
+                iii_iv_sqlite::testutils::setup_attach(client_db.clone()).await;
+            let clock = MonotonicClock::new(100000);
+
+            let state = TaskStateById::default();
+            let worker = {
+                let state = state.clone();
+                let worker = Worker::new(worker_db, clock.clone(), opts, move |task| {
+                    run_task(task, state.clone())
+                });
+                Arc::from(Mutex::from(worker))
+            };
+
+            let client = Client::new(client_db, clock.clone(), Some(worker.clone()));
+
+            TestContext { client, workers: vec![worker], clock, state }
+        }
+
+        /// Initializes an in-memory queue with `num_workers` in-process workers and a client that
+        /// is **not** configured to poke any of them when new tasks are enqueued.
+        pub(super) async fn setup_stress(opts: WorkerOptions, num_workers: usize) -> Self {
+            let client_db = iii_iv_sqlite::testutils::setup().await;
+            let worker_db: SqliteDb<SqliteWorkerTx<MockTask>> =
+                iii_iv_sqlite::testutils::setup_attach(client_db.clone()).await;
+            let clock = MonotonicClock::new(100000);
+
+            let state = TaskStateById::default();
+            let mut workers = Vec::with_capacity(num_workers);
+            for _ in 0..num_workers {
+                let worker = {
+                    let state = state.clone();
+                    let worker =
+                        Worker::new(worker_db.clone(), clock.clone(), opts.clone(), move |task| {
+                            run_task(task, state.clone())
+                        });
+                    Arc::from(Mutex::from(worker))
+                };
+                workers.push(worker);
+            }
+
+            let client = Client::new(client_db, clock.clone(), None);
+
+            TestContext { client, workers, clock, state }
+        }
+
+        /// Notifies `n` workers about the availability of new tasks.
+        pub(super) async fn notify_workers(&mut self, n: usize) {
+            for _ in 0..n {
+                let i = rand::random::<usize>() % self.workers.len();
+                self.workers[i].lock().await.notify().await.unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::testutils::*;
+    use crate::model::TaskResult;
+    use iii_iv_core::clocks::Clock;
+    use std::time::Duration;
+
+    async fn do_stress_test(num_workers: usize, num_tasks: u16, batch_size: u16) {
+        let opts = WorkerOptions {
+            batch_size,
+            max_runtime: Duration::from_millis(100000),
+            ..Default::default()
+        };
+        let mut context = TestContext::setup_stress(opts.clone(), num_workers).await;
+
+        let before = context.clock.now_utc();
+
+        // Insert a bunch of tasks.
+        let mut ids = vec![];
+        for i in 0..num_tasks {
+            let task = MockTask { id: i, result: Ok(()), crash: 0 };
+            ids.push(context.client.enqueue(&task).await.unwrap());
+            if i % (opts.batch_size * 2) == 0 {
+                context.notify_workers(num_workers / 4 + 1).await;
+            }
+        }
+        context.notify_workers(1).await;
+
+        // Poll until all tasks complete.
+        let period = Duration::from_millis(10);
+        context.client.wait_all(&ids, before, period).await.unwrap();
+
+        // Verify that all tasks completed.
+        let mut state = context.state.lock().await;
+        for i in 0..num_tasks {
+            match state.remove(&i) {
+                Some(s) => assert_eq!(1, s.runs, "Task {} should have run one time only", i),
+                None => panic!("Task {} did not complete", i),
+            }
+        }
+        assert!(state.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_stress_smoke_no_threads() {
+        do_stress_test(1, 100, 5).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_smoke_multiple_threads() {
+        do_stress_test(1, 100, 5).await;
+    }
+
+    #[ignore = "Takes longer than a unit test should"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_one_worker() {
+        do_stress_test(1, 10000, 5).await;
+    }
+
+    #[ignore = "Takes longer than a unit test should"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_many_workers() {
+        do_stress_test(10, 10000, 20).await;
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_crash_always_fails() {
+        let mut context = TestContext::setup_one_connected(WorkerOptions {
+            max_runtime: Duration::from_millis(1),
+            max_runs: 5,
+            ..Default::default()
+        })
+        .await;
+
+        let task = MockTask { id: 123, result: Ok(()), crash: 4 };
+        let id = context.client.enqueue(&task).await.unwrap();
+        let result = context.client.wait(id, Duration::from_millis(1)).await.unwrap();
+
+        let state = context.state.lock().await;
+        assert_eq!(1, state.len());
+        assert_eq!(4, state.get(&123).unwrap().runs);
+        match result {
+            TaskResult::Abandoned(_) => (),
+            _ => panic!("Unexpected result {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_crash_eventually_passes() {
+        let mut context = TestContext::setup_one_connected(WorkerOptions {
+            max_runtime: Duration::from_millis(1),
+            max_runs: 5,
+            ..Default::default()
+        })
+        .await;
+
+        let task = MockTask { id: 123, result: Err("foo bar".to_owned()), crash: 3 };
+        let id = context.client.enqueue(&task).await.unwrap();
+        let result = context.client.wait(id, Duration::from_millis(1)).await.unwrap();
+
+        let state = context.state.lock().await;
+        assert_eq!(1, state.len());
+        assert_eq!(4, state.get(&123).unwrap().runs);
+        match result {
+            TaskResult::Failed(msg) => assert!(msg.contains("foo bar")),
+            _ => panic!("Unexpected result {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_crash_does_not_run_before_max_runtime() {
+        let mut context = TestContext::setup_one_connected(WorkerOptions {
+            max_runtime: Duration::from_secs(3600),
+            max_runs: 5,
+            ..Default::default()
+        })
+        .await;
+
+        let task = MockTask { id: 123, result: Ok(()), crash: 1 };
+        let id = context.client.enqueue(&task).await.unwrap();
+        for _ in 0..100 {
+            if let Some(_result) = context.client.poll(id).await.unwrap() {
+                panic!("Task completed but it should have not");
+            }
+
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            context.notify_workers(1).await;
+        }
+
+        let state = context.state.lock().await;
+        assert_eq!(1, state.len());
+        assert_eq!(1, state.get(&123).unwrap().runs);
+    }
+}

--- a/queue/src/driver/worker.rs
+++ b/queue/src/driver/worker.rs
@@ -1,0 +1,312 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Background task to extract tasks from the queue and run them.
+
+use crate::db::WorkerTx;
+use crate::model::{ExecError, ExecResult, RunnableTask, TaskResult};
+use derivative::Derivative;
+use futures::channel::mpsc::{self, Sender};
+use futures::future::join_all;
+use futures::stream::StreamExt;
+use futures::{Future, SinkExt};
+use iii_iv_core::clocks::Clock;
+use iii_iv_core::db::{BareTx, Db};
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::env::get_optional_var;
+use log::{info, warn};
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+/// Default batch size.
+const DEFAULT_BATCH_SIZE: u16 = 16;
+
+/// Default max runs for a task.
+const DEFAULT_MAX_RUNS: u8 = 4;
+
+/// Default max runtime, in seconds.  We assume that we run on Azure Functions with the default
+/// maximum runtime of the Consumption Plan, which is 5 minutes.
+const DEFAULT_MAX_RUNTIME_SECS: u64 = 5 * 60;
+
+/// Configuration options for the queue worker.
+#[derive(Clone)]
+pub struct WorkerOptions {
+    /// Number of tasks to try to process during each processing cycle.
+    pub batch_size: u16,
+
+    /// Number of times a task is allowed to run before being abandoned.
+    pub max_runs: u8,
+
+    /// Maximum amount of time a task is expected to run.
+    ///
+    /// This is used to compute task timeouts and thus to decide when it is safe to start retrying
+    /// a previously-running task.  This time should be longer than a task is ever allowed to run,
+    /// which currently relies on the Azure Functions runtime (or some other serverless runtime)
+    /// to cancel execution.
+    pub max_runtime: Duration,
+}
+
+#[cfg(any(test, feature = "testutils"))]
+impl Default for WorkerOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_BATCH_SIZE,
+            max_runs: DEFAULT_MAX_RUNS,
+            max_runtime: Duration::from_secs(DEFAULT_MAX_RUNTIME_SECS),
+        }
+    }
+}
+
+impl WorkerOptions {
+    /// Creates a new set of options from environment variables.
+    pub fn from_env(prefix: &str) -> Result<Self, String> {
+        Ok(Self {
+            batch_size: get_optional_var::<u16>(prefix, "BATCH_SIZE")?
+                .unwrap_or(DEFAULT_BATCH_SIZE),
+            max_runs: get_optional_var::<u8>(prefix, "MAX_RUNS")?.unwrap_or(DEFAULT_MAX_RUNS),
+            max_runtime: get_optional_var::<Duration>(prefix, "MAX_RUNTIME")?
+                .unwrap_or(Duration::from_secs(DEFAULT_MAX_RUNTIME_SECS)),
+        })
+    }
+}
+
+/// Runs the runnable `task`, recording state transitions in `db` and using `clock` to stamp
+/// them.
+///
+/// If the task has already attempted to run `max_runs` times, the task is marked as abandoned
+/// and no further processing is attempted.
+///
+/// If the task is already running according to its state (a computation that requires knowing
+/// `max_runtime`), returns an error.
+///
+/// Task errors are recorded within the task's result.  Therefore, this function only returns
+/// errors if it encounters problems persisting state to the database.
+async fn run_task<C, D, Exec, ExecFut, T>(
+    task: RunnableTask<T>,
+    exec: Exec,
+    max_runs: u8,
+    max_runtime: Duration,
+    db: D,
+    clock: C,
+) -> DriverResult<Option<TaskResult>>
+where
+    C: Clock + Clone + Send + Sync,
+    D: Db + Clone + Send + Sync,
+    D::Tx: WorkerTx<T = T> + From<D::SqlxTx> + Send + Sync,
+    Exec: Fn(T) -> ExecFut,
+    ExecFut: Future<Output = ExecResult>,
+    T: Send + Sync,
+{
+    let id = task.id();
+
+    // This protects against running the same task concurrently more than once if we think it is
+    // still running.
+    let mut tx = db.begin().await?;
+    let task = tx.set_task_running(task, max_runtime, clock.now_utc()).await?;
+    tx.commit().await?;
+
+    let result = if task.runs() >= max_runs {
+        TaskResult::Abandoned(format!(
+            "Attempted to run {} times, but max_runs is {}",
+            task.runs(),
+            max_runs
+        ))
+    } else {
+        match task.into_json_task() {
+            Ok(task) => match exec(task).await {
+                Ok(()) => TaskResult::Done,
+
+                Err(ExecError::Failed(msg)) => TaskResult::Failed(msg),
+
+                #[cfg(test)]
+                Err(ExecError::SimulatedCrash) => {
+                    // If we want to simulate a crash during execution, return now before committing
+                    // any result to the database.
+                    return Ok(None);
+                }
+            },
+            Err(e) => TaskResult::Abandoned(format!("JSON deserialization failed: {}", e)),
+        }
+    };
+
+    // A this point, the task has already completed execution and we recorded that it did run in
+    // its `runs` counter.  Unfortunately, if we fail to persist the task's result here, the task
+    // will be considered for execution again in the future, and thus it is possible for it to
+    // run more than once.
+    //
+    // TODO(jmmv): Consider adding some form of retries here given the criticality of the situation
+    // to minimize the chances of this being a problem.  And also expose the `runs` counter to the
+    // task so that it can decide whether it actually wants to retry non-idempotent steps.
+    let mut tx = db.begin().await?;
+    tx.set_task_result(id, &result, clock.now_utc()).await?;
+    tx.commit().await?;
+
+    Ok(Some(result))
+}
+
+/// Performs one cycle to process tasks from the queue until no more runnable tasks are found.
+///
+/// The loop extracts tasks from `db` according to `opts` and executes each of them with `exec`.
+///
+/// This returns an error only if there are problems talking to the database.  The caller has to
+/// decide if it's worth retrying the cycle or not.
+pub(super) async fn loop_once<C, D, T, Exec, ExecFut>(
+    db: D,
+    clock: C,
+    opts: &WorkerOptions,
+    exec: Exec,
+) -> DriverResult<()>
+where
+    C: Clock + Clone + Send + Sync,
+    D: Db + Clone + Send + Sync,
+    D::Tx: WorkerTx<T = T> + From<D::SqlxTx> + Send + Sync,
+    Exec: Fn(T) -> ExecFut + Clone,
+    ExecFut: Future<Output = ExecResult>,
+    T: Send + Sync,
+{
+    loop {
+        let tasks = {
+            let mut tx = db.begin().await?;
+            let tasks =
+                tx.get_runnable_tasks(opts.batch_size, opts.max_runtime, clock.now_utc()).await?;
+            tx.commit().await?;
+            tasks
+        };
+
+        if tasks.is_empty() {
+            // No more tasks at this point.  Terminate cycle.
+            break Ok(());
+        }
+
+        let mut ids = Vec::with_capacity(tasks.len());
+        let mut futures = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            info!("Task {}: starting", task.id());
+            ids.push(task.id());
+            futures.push(run_task(
+                task,
+                exec.clone(),
+                opts.max_runs,
+                opts.max_runtime,
+                db.clone(),
+                clock.clone(),
+            ));
+        }
+
+        let mut failed = 0;
+        let results = join_all(futures).await;
+        for (id, result) in ids.into_iter().zip(results) {
+            match result {
+                Ok(Some(result)) => {
+                    info!("Task {}: finished with {:?}", id, result);
+                }
+
+                Ok(None) => {
+                    // If we are simulating a crash, abort processing of this whole loop early.
+                    // This isn't exactly what would happen in real life, but attempting to panic
+                    // in the task handler and trying to gracefully handle this condition is
+                    // pretty difficult.
+                    if cfg!(test) {
+                        warn!("Task {}: simulated crash", id);
+                        failed += 1;
+                        break;
+                    } else {
+                        unreachable!("Simulated crashes should only happen in tests");
+                    }
+                }
+
+                Err(e) => {
+                    // There is not much we can do if trying to run a task failed due to
+                    // problems talking to the database.  Log the fact and move on.  The task
+                    // will be retried later once `max_runtime` has elapsed.
+                    warn!("Task {}: failed to persist state: {}", id, e);
+                    failed += 1;
+                }
+            }
+        }
+        if failed > 0 {
+            // If one or more tasks failed, it is likely that we won't be able to process any more
+            // right now.  Give up and hope that the next cycle will succeed.
+            break Err(DriverError::BackendError(format!("Failed to process {} tasks", failed)));
+        }
+    }
+}
+
+/// The queue worker used to run tasks of type `T` with an `Exec`/`ExecFut` function.
+///
+/// This driver wraps a single queue worker and offers mechanisms to interact with it in an async
+/// manner.
+///
+/// This worker is clonable to support having multiple call sites interacting with the single
+/// worker at once.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct Worker<T>
+where
+    T: Send + Sync,
+{
+    /// Background task processing loop.
+    _worker: Arc<JoinHandle<()>>,
+
+    /// Communication channel with the `worker` to trigger processing cycles.
+    control_tx: Sender<()>,
+
+    /// The type of the tasks handled by this worker.
+    _data: PhantomData<T>,
+}
+
+impl<T> Worker<T>
+where
+    T: Send + Sync,
+{
+    /// Creates a new driver backed by `db` and a `clock`, configured to handle tasks according
+    /// to `opts` and using `exec` to run the tasks.
+    pub fn new<C, D, Exec, ExecFut>(db: D, clock: C, opts: WorkerOptions, exec: Exec) -> Self
+    where
+        C: Clock + Clone + Send + Sync + 'static,
+        D: Db + Clone + Send + Sync + 'static,
+        D::Tx: WorkerTx<T = T> + From<D::SqlxTx> + Send + Sync + 'static,
+        Exec: Fn(T) -> ExecFut + Clone + Send + Sync + 'static,
+        ExecFut: Future<Output = ExecResult> + Send + 'static,
+    {
+        let (control_tx, mut control_rx) = mpsc::channel(1);
+        let worker = tokio::spawn(async move {
+            while let Some(()) = control_rx.next().await {
+                let result = loop_once(db.clone(), clock.clone(), &opts, exec.clone()).await;
+                if let Err(e) = result {
+                    warn!("Task processing cycle failed: {}; will retry later", e);
+                }
+            }
+        });
+        Self { _worker: Arc::from(worker), control_tx, _data: PhantomData }
+    }
+
+    /// Triggers execution of a processing cycle in the background.
+    pub async fn notify(&mut self) -> DriverResult<()> {
+        match self.control_tx.send(()).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.is_full() => {
+                // The worker task loops until all tasks have been processed, so if we fail to
+                // enqueue a notification due to capacity issues, it means that the loop was
+                // already busy processing tasks and there is a pending notification to retry
+                // the loop.  There is no need to insert another.
+                Ok(())
+            }
+            Err(e) => Err(DriverError::BackendError(format!("Cannot awaken worker task: {}", e))),
+        }
+    }
+}

--- a/queue/src/lib.rs
+++ b/queue/src/lib.rs
@@ -1,0 +1,38 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! A persistent task queue.
+//!
+//! This crate provides facilities to implement a persistent task queue backed
+//! by a database.
+//!
+//! The client offered by `driver::Client` enqueues new tasks and fetches details
+//! about their status by directly querying the database.  There can be as many
+//! different clients as necessary accessing the tasks in this way.
+//!
+//! The worker offered by `driver::Worker` polls for tasks whenever it is poked
+//! by an external actor and executes those tasks.  This is designed to work in
+//! the context of a serverless process, but could also be un in a long-lived
+//! process.  There can also be multiple workers.
+
+// Keep these in sync with other top-level files.
+#![warn(anonymous_parameters, bad_style, clippy::missing_docs_in_private_items, missing_docs)]
+#![warn(unused, unused_extern_crates, unused_import_braces, unused_qualifications)]
+#![warn(unsafe_code)]
+
+pub mod db;
+pub mod driver;
+pub mod model;
+pub mod rest;

--- a/queue/src/model.rs
+++ b/queue/src/model.rs
@@ -1,0 +1,182 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Generic data types for the queue.
+//!
+//! State transitions for a task are represented as different types, each with the minimal
+//! set of data required to represent the state.  There is no single type that represents
+//! the full state of a task as stored in the database because such a type is unnecessary
+//! at runtime and introduces the possibility of invalid in-memory states.
+//!
+//! A consequence of the above is that certain properties of a task that are stored in the
+//! database are not accessible from the data model.  For example: the creation time of a
+//! task is required only to enqueue a task into the queue and it is useful to keep this
+//! detail in the database for troubleshooting purposes---but the consumers of the task
+//! have no need for this information.
+//!
+//! Task execution is decoupled from task representation.  The queue only cares about the
+//! ability to serialize and deserialize task definitions, and it must be possible for the
+//! clients of the queue to enqueue tasks without knowing how to execute them.  This poses
+//! difficulties in mutating in-process state from the tasks, but that's very much
+//! intentional because it should not be done.
+
+#[cfg(test)]
+use derivative::Derivative;
+use iii_iv_core::{db::DbError, driver::DriverError};
+use serde_json::Result as SerdeJsonResult;
+use uuid::Uuid;
+
+/// Describes the completion state of the task.
+#[derive(Debug)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Clone, Eq, PartialEq))]
+pub enum TaskResult {
+    /// The task successfully completed execution.
+    Done,
+
+    /// The task finished processing but it failed with the given reason.
+    Failed(String),
+
+    /// The task failed to run after a configurable amount of max runs, so it is now abandoned
+    /// (quarantined).  The associated string contains details on the reason for abandonment.
+    Abandoned(String),
+}
+
+/// Error type returned by the closure used to run tasks.
+pub enum ExecError {
+    /// Indicates that the task has failed in a controlled manner.
+    Failed(String),
+
+    /// Simulates that the task has caused the worker to crash.
+    //
+    // TODO(jmmv): It would be nice to trigger an actual crash via a `panic`, but it's not
+    // easy to make the code panic-safe and I'm not sure what kind of restrictions that would
+    // impose on the execution logic.
+    #[cfg(test)]
+    SimulatedCrash,
+}
+
+impl From<DbError> for ExecError {
+    fn from(value: DbError) -> Self {
+        // In the common case, the closure used to run tasks lives in the driver layer and
+        // thus deals with errors of type `DriverError`.  But given that all we will do with
+        // the error is persist it in the database as a string, we can perform this flattening
+        // here and forget about different types.
+        ExecError::Failed(value.to_string())
+    }
+}
+
+impl From<DriverError> for ExecError {
+    fn from(value: DriverError) -> Self {
+        // In the common case, the closure used to run tasks lives in the driver layer and
+        // thus deals with errors of type `DriverError`.  But given that all we will do with
+        // the error is persist it in the database as a string, we can perform this flattening
+        // here and forget about different types.
+        ExecError::Failed(value.to_string())
+    }
+}
+
+/// Result type returned by the closue used to run tasks.
+pub type ExecResult = Result<(), ExecError>;
+
+/// A runnable task.
+///
+/// Runnable tasks are those that have never started running or that may have started running
+/// in the past but whose worker died prior task completion.
+///
+/// To distinguish the two cases above, and to prevent a bad task from poisoning execution
+/// perpetually, tasks have a `runs` counter that specify how many times they have been
+/// attempted.
+#[cfg_attr(test, derive(Derivative))]
+#[cfg_attr(test, derivative(Debug, PartialEq))]
+pub struct RunnableTask<T: Send + Sync> {
+    /// Unique identifier of the task.
+    id: Uuid,
+
+    /// Task description as extracted from the database.
+    #[cfg_attr(test, derivative(PartialEq(compare_with = "crate::model::cmp_json_task")))]
+    json_task: SerdeJsonResult<T>,
+
+    /// Number of times the task started to run.
+    runs: u8,
+}
+
+impl<T: Send + Sync> RunnableTask<T> {
+    /// Creates a new runnable task as extracted from the database.
+    pub(crate) fn new(id: Uuid, json_task: SerdeJsonResult<T>, runs: u8) -> Self {
+        Self { id, json_task, runs }
+    }
+
+    /// Returns the unique identifier for the task.
+    pub(crate) fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// Transitions the task into the running state.
+    ///
+    /// This must be called only after the task has been marked as running in the database,
+    /// and the `runs` counter in the database must be updated to account for this new run.
+    pub(crate) fn try_run(self) -> RunningTask<T> {
+        RunningTask { id: self.id, json_task: self.json_task, runs: self.runs + 1 }
+    }
+
+    /// Extracts the deserialized task in order to inspect it.
+    #[cfg(feature = "testutils")]
+    pub fn into_json_task(self) -> SerdeJsonResult<T> {
+        self.json_task
+    }
+}
+
+/// A running task.
+///
+/// This type provides access to the task description and the ability to apply an execution
+/// function to produce a task result.
+#[cfg_attr(test, derive(Derivative))]
+#[cfg_attr(test, derivative(Debug, PartialEq))]
+pub struct RunningTask<T: Send + Sync> {
+    /// Unique identifier of the task.
+    id: Uuid,
+
+    /// Task description as extracted from the database.
+    #[cfg_attr(test, derivative(PartialEq(compare_with = "crate::model::cmp_json_task")))]
+    json_task: SerdeJsonResult<T>,
+
+    /// Number of times the task started to run.
+    runs: u8,
+}
+
+impl<T: Send + Sync> RunningTask<T> {
+    /// Returns the unique identifier for the task.
+    pub(crate) fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// Returns the number of times the task started to run, including this execution attempt.
+    pub(crate) fn runs(&self) -> u8 {
+        self.runs
+    }
+
+    /// Extracts the deserialized task in order to run it.
+    pub(crate) fn into_json_task(self) -> SerdeJsonResult<T> {
+        self.json_task
+    }
+}
+
+/// Compares two JSON task deserialization results for testing purposes only.
+#[cfg(test)]
+fn cmp_json_task<T: PartialEq>(lhs: &SerdeJsonResult<T>, rhs: &SerdeJsonResult<T>) -> bool {
+    let lhs = lhs.as_ref().map_err(|e| e.to_string());
+    let rhs = rhs.as_ref().map_err(|e| e.to_string());
+    lhs == rhs
+}

--- a/queue/src/rest/mod.rs
+++ b/queue/src/rest/mod.rs
@@ -1,0 +1,42 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Common REST endpoints to interact with the queue.
+//!
+//! In order to use these endpoints, you must copy the contents of the `functions`
+//! directory supplied with this crate into the functions that your Azure Functions
+//! deployment provides.  You will need a similar triggering mechanism for other
+//! runtimes.  Note that the runtime must enforce a maximum execution time for the
+//! process to guarantee correctness.
+
+use crate::driver::Worker;
+use axum::Router;
+use futures::lock::Mutex;
+use std::sync::Arc;
+
+mod queue_loop;
+#[cfg(test)]
+mod testutils;
+
+/// Creates the router for the queue worker endpoints that are directly invoked
+/// by the Azure Functions runtime.  These routes **must not** be nested under other
+/// paths.
+pub fn worker_cron_app<T>(worker: Arc<Mutex<Worker<T>>>) -> Router
+where
+    T: Send + Sync + 'static,
+{
+    use axum::routing::post;
+    Router::new().route("/queue-loop", post(queue_loop::cron_post_handler)).with_state(worker)
+}

--- a/queue/src/rest/queue_loop.rs
+++ b/queue/src/rest/queue_loop.rs
@@ -1,0 +1,100 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! API to start a processing loop as invoked by the Azure Functions runtime via
+//! a `timerTrigger` scheduled trigger.
+
+use crate::driver::Worker;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::{http, Json};
+use futures::lock::Mutex;
+use iii_iv_core::rest::RestError;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// POST handler for this cron trigger.
+///
+/// This handler **must** be installed at the root of the web server, not within the standard
+/// `/api` path, and its name must match the name of the corresponding `function.json` file.
+pub async fn cron_post_handler<T>(
+    State(worker): State<Arc<Mutex<Worker<T>>>>,
+    // TODO(jmmv): Should deserialize the timer request and do something with it, but for now just
+    // consume and ignore it.
+    _body: String,
+) -> Result<impl IntoResponse, RestError>
+where
+    T: Send + Sync + 'static,
+{
+    {
+        let mut worker = worker.lock().await;
+        worker.notify().await?;
+    }
+
+    // The empty JSON dictionary is necessary in the response to keep the Azure Functions runtime
+    // happy.  If we don't supply this in the response, the runtime thinks the function has not
+    // terminated.  And if we supply a different content type, the runtime raises an error.
+    let result: HashMap<String, String> = HashMap::default();
+    Ok((http::StatusCode::OK, Json(result)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::TaskResult;
+    use crate::rest::testutils::*;
+    use axum::http;
+    use iii_iv_core::rest::testutils::*;
+    use std::{collections::HashMap, time::Duration};
+
+    /// Constructs a URL to call the method/API under test.
+    fn route() -> (http::Method, String) {
+        (http::Method::POST, "/queue-loop".to_owned())
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mut context = TestContext::setup().await;
+
+        let id = context
+            .client
+            .enqueue(&MockTask { result: Err("the result".to_string()) })
+            .await
+            .unwrap();
+
+        // Give some time to the worker to execute the task.  We expect this to *not* happen
+        // because the worker has not been notified that a new task is ready for execution (the
+        // client created by `TestContext::setup` is not connected to a worker. Obviously this
+        // is racy and might not detect a real bug, but we should not get any false negatives.
+        for _ in 0..10 {
+            let result = context.client.poll(id).await.unwrap();
+            assert!(
+                result.is_none(),
+                "Task should not have completed because we didn't poll the worker yet"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        let response = OneShotBuilder::new(context.app(), route())
+            .send_empty()
+            .await
+            .expect_json::<HashMap<String, String>>()
+            .await;
+        assert!(response.is_empty());
+
+        // Now that we poked the worker via the REST API, we can expect the task to complete.
+        let result = context.client.wait(id, Duration::from_millis(1)).await.unwrap();
+        assert_eq!(TaskResult::Failed("the result".to_string()), result);
+    }
+}

--- a/queue/src/rest/testutils.rs
+++ b/queue/src/rest/testutils.rs
@@ -1,0 +1,76 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use crate::db::{SqliteClientTx, SqliteWorkerTx};
+use crate::driver::{Client, Worker, WorkerOptions};
+use crate::model::{ExecError, ExecResult};
+use crate::rest::worker_cron_app;
+use axum::Router;
+use futures::lock::Mutex;
+use iii_iv_core::clocks::testutils::MonotonicClock;
+use iii_iv_sqlite::SqliteDb;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// A task definition for testing purposes.
+#[derive(Deserialize, Serialize)]
+pub(super) struct MockTask {
+    /// What the task will return upon execution.
+    pub(super) result: Result<(), String>,
+}
+
+/// Executes `task`.
+async fn run_task(task: MockTask) -> ExecResult {
+    task.result.map_err(ExecError::Failed)
+}
+
+/// State of a running test.
+pub(super) struct TestContext {
+    /// Instance of the app under test.
+    app: Router,
+
+    /// Queue client to interact with the tasks handled by `app`.
+    pub(super) client: Client<MockTask, MonotonicClock, SqliteDb<SqliteClientTx<MockTask>>>,
+}
+
+impl TestContext {
+    /// Initializes a REST app using an in-memory datababase with an in-process worker and a
+    /// client that is **not** connected to the worker.
+    pub(super) async fn setup() -> TestContext {
+        let client_db = iii_iv_sqlite::testutils::setup().await;
+        let worker_db: SqliteDb<SqliteWorkerTx<MockTask>> =
+            iii_iv_sqlite::testutils::setup_attach(client_db.clone()).await;
+        let clock = MonotonicClock::new(100000);
+
+        let worker = {
+            let opts = WorkerOptions::default();
+            let worker = Worker::new(worker_db, clock.clone(), opts, run_task);
+            Arc::from(Mutex::from(worker))
+        };
+
+        // The client is not connected to the worker so that we can validate that the worker loop
+        // isn't invoked until we ask for it.
+        let client = Client::new(client_db, clock, None);
+
+        let app = worker_cron_app(worker);
+
+        TestContext { client, app }
+    }
+
+    /// Gets a clone of the app router.
+    pub(super) fn app(&self) -> Router {
+        self.app.clone()
+    }
+}


### PR DESCRIPTION
The new queue crate provides the features needed to implement a persistent task queue: a client to enqueue and query tasks, and a worker to run those tasks in the context of an Azure Functions deployment.