### PR TITLE
Allow successful tasks to carry a message

### DIFF
--- a/queue/src/db/tests.rs
+++ b/queue/src/db/tests.rs
@@ -265,9 +265,11 @@ where
     )
     .await;
 
-    for result in
-        [TaskResult::Done, TaskResult::Failed("".to_owned()), TaskResult::Abandoned("".to_owned())]
-    {
+    for result in [
+        TaskResult::Done(None),
+        TaskResult::Failed("".to_owned()),
+        TaskResult::Abandoned("".to_owned()),
+    ] {
         // Put a few tasks that are done and that are outside of the max_runtime window.
         // Must NOT be considered as runnable anymore.
         put_done_task(
@@ -447,7 +449,7 @@ pub(super) async fn test_set_task_running_fails_if_already_completed<CD, WD>(
     let now = datetime!(2023-06-01 06:50 UTC);
 
     for result in [
-        TaskResult::Done,
+        TaskResult::Done(None),
         TaskResult::Failed("foo".to_owned()),
         TaskResult::Abandoned("bar".to_owned()),
     ] {
@@ -546,7 +548,7 @@ where
 {
     let max_runtime = Duration::from_millis(10);
     for exp_result in [
-        TaskResult::Done,
+        TaskResult::Done(None),
         TaskResult::Failed("foo".to_owned()),
         TaskResult::Abandoned("bar".to_owned()),
     ] {
@@ -588,10 +590,13 @@ where
     put_running_task(&client_db, &worker_db, 4, max_runtime, after, 5).await;
 
     let mut exp_results = vec![];
-    for (i, result) in
-        [TaskResult::Done, TaskResult::Failed("".to_owned()), TaskResult::Abandoned("".to_owned())]
-            .iter()
-            .enumerate()
+    for (i, result) in [
+        TaskResult::Done(None),
+        TaskResult::Failed("".to_owned()),
+        TaskResult::Abandoned("".to_owned()),
+    ]
+    .iter()
+    .enumerate()
     {
         // The results of the query are sorted by timestamp, so make sure they are stable by using
         // different values for each task.

--- a/queue/src/driver/worker.rs
+++ b/queue/src/driver/worker.rs
@@ -138,7 +138,7 @@ where
     } else {
         match task.into_json_task() {
             Ok(task) => match exec(task).await {
-                Ok(()) => TaskResult::Done,
+                Ok(msg) => TaskResult::Done(msg),
 
                 Err(ExecError::Failed(msg)) => TaskResult::Failed(msg),
 

--- a/queue/src/model.rs
+++ b/queue/src/model.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 #[cfg_attr(any(test, feature = "testutils"), derive(Clone, Eq, PartialEq))]
 pub enum TaskResult {
     /// The task successfully completed execution.
-    Done,
+    Done(Option<String>),
 
     /// The task finished processing but it failed with the given reason.
     Failed(String),
@@ -88,7 +88,7 @@ impl From<DriverError> for ExecError {
 }
 
 /// Result type returned by the closue used to run tasks.
-pub type ExecResult = Result<(), ExecError>;
+pub type ExecResult = Result<Option<String>, ExecError>;
 
 /// A runnable task.
 ///


### PR DESCRIPTION
Modify the task result type so that tasks that finish successfully can specify an optional diagnostics message that is saved as their completion status.