### PR TITLE
Allow tuning the number of connections to Postgres

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn serve(
     bind_addr: impl Into<SocketAddr>,
     db_opts: PostgresOptions,
 ) -> Result<(), Box<dyn Error>> {
-    let pool = PostgresPool::connect(db_opts).await?;
+    let pool = PostgresPool::connect(db_opts)?;
     let db = PostgresDb::<PostgresTx>::attach(pool).await?;
     let driver = Driver::new(db);
     let app = app(driver);


### PR DESCRIPTION
Add extra configuration variables to control the number of minimum and maximum connections to keep open in a Postgres pool.