### PR TITLE
Rename example Tx to KVStoreTx

### DIFF
--- a/example/src/db/mod.rs
+++ b/example/src/db/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod tests;
 
 /// A transaction with high-level operations that deal with our types.
 #[async_trait::async_trait]
-pub(crate) trait Tx: BareTx {
+pub(crate) trait KVStoreTx: BareTx {
     /// Gets a list of all existing keys.
     async fn get_keys(&mut self) -> DbResult<BTreeSet<Key>>;
 

--- a/example/src/db/tests.rs
+++ b/example/src/db/tests.rs
@@ -15,14 +15,14 @@
 
 //! Database tests shared by all implementations.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::model::*;
 use iii_iv_core::db::{BareTx, Db, DbError};
 
 pub(crate) async fn test_sequence_one<D>(db: D)
 where
     D: Db,
-    D::Tx: Tx,
+    D::Tx: KVStoreTx,
 {
     let key = Key::new("the-key".to_owned());
 
@@ -52,7 +52,7 @@ where
 pub(crate) async fn test_multiple_keys<D>(db: D)
 where
     D: Db,
-    D::Tx: Tx,
+    D::Tx: KVStoreTx,
 {
     let key1 = Key::new("key 1".to_owned());
     let key2 = Key::new("key 2".to_owned());

--- a/example/src/driver/key.rs
+++ b/example/src/driver/key.rs
@@ -15,7 +15,7 @@
 
 //! Operations on one key.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::*;
 use iii_iv_core::db::{BareTx, Db};
@@ -24,7 +24,7 @@ use iii_iv_core::driver::DriverResult;
 impl<D> Driver<D>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     /// Deletes an existing `key`.
     pub(crate) async fn delete_key(self, key: &Key) -> DriverResult<()> {

--- a/example/src/driver/keys.rs
+++ b/example/src/driver/keys.rs
@@ -15,7 +15,7 @@
 
 //! Operations on a collection of keys.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::*;
 use iii_iv_core::db::{BareTx, Db};
@@ -25,7 +25,7 @@ use std::collections::BTreeSet;
 impl<D> Driver<D>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     /// Gets a list of all existing keys.
     pub(crate) async fn get_keys(self) -> DriverResult<BTreeSet<Key>> {

--- a/example/src/driver/mod.rs
+++ b/example/src/driver/mod.rs
@@ -15,7 +15,7 @@
 
 //! Business logic for the service.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use iii_iv_core::db::Db;
 
 mod key;
@@ -33,7 +33,7 @@ mod testutils;
 pub(crate) struct Driver<D>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     /// The database that the driver uses for persistence.
     db: D,
@@ -42,7 +42,7 @@ where
 impl<D> Driver<D>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     /// Creates a new driver backed by the given injected components.
     pub(crate) fn new(db: D) -> Self {

--- a/example/src/driver/testutils.rs
+++ b/example/src/driver/testutils.rs
@@ -15,28 +15,28 @@
 
 //! Test utilities for the business layer.
 
-use crate::db::sqlite::SqliteTx;
+use crate::db::sqlite::SqliteKVStoreTx;
 use crate::driver::Driver;
 use iii_iv_sqlite::{self, SqliteDb};
 
 pub(crate) struct TestContext {
-    db: SqliteDb<SqliteTx>,
-    driver: Driver<SqliteDb<SqliteTx>>,
+    db: SqliteDb<SqliteKVStoreTx>,
+    driver: Driver<SqliteDb<SqliteKVStoreTx>>,
 }
 
 impl TestContext {
     pub(crate) async fn setup() -> Self {
         let pool = iii_iv_sqlite::connect(":memory:").await.unwrap();
-        let db = SqliteDb::<SqliteTx>::attach(pool).await.unwrap();
+        let db = SqliteDb::<SqliteKVStoreTx>::attach(pool).await.unwrap();
         let driver = Driver::new(db.clone());
         Self { db, driver }
     }
 
-    pub(crate) fn db(&self) -> &SqliteDb<SqliteTx> {
+    pub(crate) fn db(&self) -> &SqliteDb<SqliteKVStoreTx> {
         &self.db
     }
 
-    pub(crate) fn driver(&self) -> Driver<SqliteDb<SqliteTx>> {
+    pub(crate) fn driver(&self) -> Driver<SqliteDb<SqliteKVStoreTx>> {
         self.driver.clone()
     }
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -25,7 +25,7 @@ use std::error::Error;
 use std::net::SocketAddr;
 
 pub mod db;
-use db::postgres::PostgresTx;
+use db::postgres::PostgresKVStoreTx;
 pub mod driver;
 use driver::Driver;
 pub(crate) mod model;
@@ -41,7 +41,7 @@ pub async fn serve(
     db_opts: PostgresOptions,
 ) -> Result<(), Box<dyn Error>> {
     let pool = PostgresPool::connect(db_opts)?;
-    let db = PostgresDb::<PostgresTx>::attach(pool).await?;
+    let db = PostgresDb::<PostgresKVStoreTx>::attach(pool).await?;
     let driver = Driver::new(db);
     let app = app(driver);
 

--- a/example/src/rest/key_delete.rs
+++ b/example/src/rest/key_delete.rs
@@ -15,7 +15,7 @@
 
 //! API to delete a key.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::Key;
 use axum::extract::{Path, State};
@@ -31,7 +31,7 @@ pub(crate) async fn handler<D>(
 ) -> Result<impl IntoResponse, RestError>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     driver.delete_key(&key).await?;
 

--- a/example/src/rest/key_get.rs
+++ b/example/src/rest/key_get.rs
@@ -15,7 +15,7 @@
 
 //! API to get the latest version of a key.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::Key;
 use axum::extract::{Path, State};
@@ -32,7 +32,7 @@ pub(crate) async fn handler<D>(
 ) -> Result<impl IntoResponse, RestError>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     let entry = driver.get_key(&key).await?;
     Ok(Json(entry))

--- a/example/src/rest/key_put.rs
+++ b/example/src/rest/key_put.rs
@@ -15,7 +15,7 @@
 
 //! API to create or update a key.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::{Key, Version};
 use axum::extract::{Path, State};
@@ -32,7 +32,7 @@ pub(crate) async fn handler<D>(
 ) -> Result<(http::StatusCode, impl IntoResponse), RestError>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     let value = driver.set_key(&key, body).await?;
     let code = if *value.version() == Version::initial() {

--- a/example/src/rest/keys_get.rs
+++ b/example/src/rest/keys_get.rs
@@ -15,7 +15,7 @@
 
 //! API to get all existing keys.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use axum::extract::State;
 use axum::response::IntoResponse;
@@ -30,7 +30,7 @@ pub(crate) async fn handler<D>(
 ) -> Result<impl IntoResponse, RestError>
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     let keys = driver.get_keys().await?;
 

--- a/example/src/rest/mod.rs
+++ b/example/src/rest/mod.rs
@@ -15,7 +15,7 @@
 
 //! Entry point to the REST server.
 
-use crate::db::Tx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use axum::Router;
 use iii_iv_core::db::Db;
@@ -31,7 +31,7 @@ mod testutils;
 pub(crate) fn app<D>(driver: Driver<D>) -> Router
 where
     D: Db + Clone + Send + Sync + 'static,
-    D::Tx: Tx + From<D::SqlxTx> + Send + Sync + 'static,
+    D::Tx: KVStoreTx + From<D::SqlxTx> + Send + Sync + 'static,
 {
     use axum::routing::get;
     Router::new()

--- a/example/src/rest/testutils.rs
+++ b/example/src/rest/testutils.rs
@@ -15,8 +15,8 @@
 
 //! Test utilities for the REST API.
 
-use crate::db::sqlite::SqliteTx;
-use crate::db::Tx;
+use crate::db::sqlite::SqliteKVStoreTx;
+use crate::db::KVStoreTx;
 use crate::driver::Driver;
 use crate::model::*;
 use crate::rest::app;
@@ -25,14 +25,14 @@ use iii_iv_core::db::{BareTx, Db};
 use iii_iv_sqlite::{self, SqliteDb};
 
 pub(crate) struct TestContext {
-    db: SqliteDb<SqliteTx>,
+    db: SqliteDb<SqliteKVStoreTx>,
     app: Router,
 }
 
 impl TestContext {
     pub(crate) async fn setup() -> Self {
         let pool = iii_iv_sqlite::connect(":memory:").await.unwrap();
-        let db = SqliteDb::<SqliteTx>::attach(pool).await.unwrap();
+        let db = SqliteDb::<SqliteKVStoreTx>::attach(pool).await.unwrap();
         let driver = Driver::new(db.clone());
         let app = app(driver);
         Self { db, app }


### PR DESCRIPTION
I'm going to be referencing this from a blog post, and the bare Tx name becomes very confusing because it overlaps with the generic type names.