### PR TITLE
Remove the SmtpMessenger type

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [features]
 default = []
-testutils = ["dep:futures"]
+testutils = ["dep:futures", "dep:quoted_printable"]
 
 [dependencies]
 async-trait = "0.1"
@@ -16,6 +16,7 @@ axum = "0.6"
 derivative = "2.2"
 futures = { version = "0.3", optional = true }
 http = "0.2.8"
+quoted_printable = { version = "0.5", optional = true }
 serde_json = "1"
 thiserror = "1.0"
 time = "0.3"
@@ -27,5 +28,8 @@ default-features = false
 features = ["builder", "hostname", "pool", "rustls-tls", "smtp-transport", "tokio1-rustls-tls"]
 
 [dev-dependencies]
+futures = "0.3"
 iii-iv-core = { path = "../core", features = ["testutils"] }
+quoted_printable = "0.5"
 temp-env = "0.3.2"
+tokio = { version = "1", features = ["macros"] }

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -24,9 +24,8 @@ use async_trait::async_trait;
 use derivative::Derivative;
 use iii_iv_core::driver::{DriverError, DriverResult};
 use iii_iv_core::env::get_required_var;
-use iii_iv_core::model::EmailAddress;
+pub use lettre::message::{Mailbox, Message};
 use lettre::transport::smtp::authentication::Credentials;
-pub use lettre::Message;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
 
 /// Options to establish an SMTP connection.
@@ -69,15 +68,24 @@ pub trait SmtpMailer {
 
 /// Mailer backed by a real SMTP connection using `lettre`.
 #[derive(Clone)]
-pub struct LettreSmtpMailer {
-    /// SMTP transport.
-    mailer: AsyncSmtpTransport<Tokio1Executor>,
+pub struct LettreSmtpMailer(AsyncSmtpTransport<Tokio1Executor>);
+
+impl LettreSmtpMailer {
+    /// Establishes a connection to the SMTP server.
+    pub fn connect(opts: SmtpOptions) -> Result<Self, String> {
+        let creds = Credentials::new(opts.username, opts.password);
+        let mailer = AsyncSmtpTransport::<Tokio1Executor>::relay(&opts.relay)
+            .map_err(|e| format!("{}", e))?
+            .credentials(creds)
+            .build();
+        Ok(LettreSmtpMailer(mailer))
+    }
 }
 
 #[async_trait]
 impl SmtpMailer for LettreSmtpMailer {
     async fn send(&self, message: Message) -> DriverResult<()> {
-        self.mailer
+        self.0
             .send(message)
             .await
             .map_err(|e| DriverError::BackendError(format!("SMTP communication failed: {}", e)))?;
@@ -85,87 +93,109 @@ impl SmtpMailer for LettreSmtpMailer {
     }
 }
 
-/// A `Messenger` that talks to an SMTP server to send human-readable messages to users.
-#[derive(Clone)]
-pub struct SmtpMessenger<M>
-where
-    M: SmtpMailer + Clone + Send + Sync,
-{
-    /// Abstract mailer.
-    mailer: M,
-}
-
-impl<M> SmtpMessenger<M>
-where
-    M: SmtpMailer + Clone + Send + Sync,
-{
-    /// Establishes a connection to the SMTP server.
-    pub fn connect(opts: SmtpOptions) -> SmtpMessenger<LettreSmtpMailer> {
-        let creds = Credentials::new(opts.username, opts.password);
-        let mailer = AsyncSmtpTransport::<Tokio1Executor>::relay(&opts.relay)
-            .unwrap()
-            .credentials(creds)
-            .build();
-        let mailer = LettreSmtpMailer { mailer };
-        SmtpMessenger { mailer }
-    }
-
-    /// Creates an email message from the given parts.
-    pub async fn send(
-        &self,
-        from: &str,
-        reply_to: &str,
-        to: &EmailAddress,
-        subject: &str,
-        body: String,
-    ) -> DriverResult<()> {
-        let message = Message::builder()
-            .from(from.parse().unwrap())
-            .reply_to(reply_to.parse().unwrap())
-            .to(to.as_str().parse().unwrap())
-            .subject(subject)
-            .body(body)
-            .unwrap();
-        self.mailer.send(message).await
-    }
-}
-
 /// Test utilities for email handling.
-#[cfg(feature = "testutils")]
+#[cfg(any(test, feature = "testutils"))]
 pub mod testutils {
     use super::*;
     use futures::lock::Mutex;
+    use iii_iv_core::model::EmailAddress;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
+    /// Given an SMTP `message`, parses it and extracts its headers and body.
+    pub fn parse_message(message: &Message) -> (HashMap<String, String>, String) {
+        let text = String::from_utf8(message.formatted()).unwrap();
+        let (raw_headers, encoded_body) = text
+            .split_once("\r\n\r\n")
+            .unwrap_or_else(|| panic!("Message seems to have the wrong format: {}", text));
+
+        let mut headers = HashMap::default();
+        for raw_header in raw_headers.split("\r\n") {
+            let (key, value) = raw_header
+                .split_once(": ")
+                .unwrap_or_else(|| panic!("Header seems to have the wrong format: {}", raw_header));
+            let previous = headers.insert(key.to_owned(), value.to_owned());
+            assert!(previous.is_none(), "Duplicate header {}", raw_header);
+        }
+
+        let decoded_body =
+            quoted_printable::decode(encoded_body, quoted_printable::ParseMode::Strict).unwrap();
+        let body = String::from_utf8(decoded_body).unwrap().replace("\r\n", "\n");
+
+        (headers, body)
+    }
+
     /// Mailer that captures outgoing messages.
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct RecorderSmtpMailer {
         /// Storage for captured messages.
-        pub messages: Arc<Mutex<Vec<Message>>>,
+        pub inboxes: Arc<Mutex<HashMap<EmailAddress, Vec<Message>>>>,
+
+        /// Addresses for which to fail sending a message to.
+        errors: Arc<Mutex<HashSet<EmailAddress>>>,
+    }
+
+    impl RecorderSmtpMailer {
+        /// Makes trying to send errors to `email` fail with an error.
+        pub async fn inject_error_for<E: Into<EmailAddress>>(&self, email: E) {
+            let mut errors = self.errors.lock().await;
+            errors.insert(email.into());
+        }
+
+        /// Expects that messages were sent to `exp_to` and nobody else, and returns the list of
+        /// messages to that recipient.
+        pub async fn expect_one_inbox(&self, exp_to: &EmailAddress) -> Vec<Message> {
+            let inboxes = self.inboxes.lock().await;
+            assert_eq!(1, inboxes.len(), "Expected to find just one message in one inbox");
+            let (to, messages) = inboxes.iter().next().unwrap();
+            assert_eq!(exp_to, to);
+            messages.clone()
+        }
+
+        /// Expects that only one message was sent to `exp_to` and nobody else, and returns the
+        /// message.
+        pub async fn expect_one_message(&self, exp_to: &EmailAddress) -> Message {
+            let mut messages = self.expect_one_inbox(exp_to).await;
+            assert_eq!(
+                1,
+                messages.len(),
+                "Expected to find just one message for {}",
+                exp_to.as_str()
+            );
+            messages.pop().unwrap()
+        }
     }
 
     #[async_trait]
     impl SmtpMailer for RecorderSmtpMailer {
         async fn send(&self, message: Message) -> DriverResult<()> {
-            let mut messages = self.messages.lock().await;
-            messages.push(message);
+            let to = EmailAddress::from(
+                message.headers().get_raw("To").expect("To header must have been present"),
+            );
+
+            {
+                let errors = self.errors.lock().await;
+                if errors.contains(&to) {
+                    return Err(DriverError::BackendError(format!(
+                        "Sending email to {} failed",
+                        to.as_str()
+                    )));
+                }
+            }
+
+            let mut inboxes = self.inboxes.lock().await;
+            inboxes.entry(to).or_insert_with(Vec::default).push(message);
             Ok(())
         }
-    }
-
-    /// Creates a mock messenger for testing purposes.
-    pub fn setup() -> (Arc<Mutex<Vec<Message>>>, SmtpMessenger<RecorderSmtpMailer>) {
-        let messages = Arc::from(Mutex::from(vec![]));
-        let mailer = RecorderSmtpMailer { messages: messages.clone() };
-        let messenger = SmtpMessenger { mailer };
-        (messages, messenger)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use crate::testutils::*;
+    use iii_iv_core::model::EmailAddress;
+    use std::{env, panic::catch_unwind};
 
     #[test]
     pub fn test_smtp_options_from_env_all_present() {
@@ -201,5 +231,140 @@ mod tests {
                 assert!(err.contains(&format!("{} not present", var)));
             });
         }
+    }
+
+    #[tokio::test]
+    pub async fn test_parse_message() {
+        let exp_body = "
+This is a sample message with a line that should be longer than 72 characters to test line wraps.
+
+There is also a second paragraph with = quoted printable characters.
+";
+        let message = Message::builder()
+            .from("From someone <from@example.com>".parse().unwrap())
+            .to("to@example.com".parse().unwrap())
+            .subject("This: is the: subject line")
+            .body(exp_body.to_owned())
+            .unwrap();
+
+        // Make sure the encoding of the message is quoted-printable.  This isn't strictly required
+        // because I suppose `parse_message` might succeed anyway, but it's good to encode our
+        // assumption in a test.
+        let text = String::from_utf8(message.formatted()).unwrap();
+        assert!(text.contains("=3D"));
+
+        let (headers, body) = parse_message(&message);
+
+        assert!(headers.len() >= 3);
+        assert_eq!("\"From someone\" <from@example.com>", headers.get("From").unwrap());
+        assert_eq!("to@example.com", headers.get("To").unwrap());
+        assert_eq!("This: is the: subject line", headers.get("Subject").unwrap());
+
+        assert_eq!(exp_body, body);
+    }
+
+    /// Creates a new message where the only thing that matters is toe `to` field.
+    fn new_message(to: &EmailAddress) -> Message {
+        Message::builder()
+            .from("from@example.com".parse().unwrap())
+            .to(to.as_str().parse().unwrap())
+            .subject("Test")
+            .body("Body".to_owned())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    pub async fn test_recorder_inject_error() {
+        let to1 = EmailAddress::from("to1@example.com");
+        let to2 = EmailAddress::from("to2@example.com");
+        let to3 = EmailAddress::from("to3@example.com");
+
+        let mailer = RecorderSmtpMailer::default();
+        mailer.inject_error_for(to2.clone()).await;
+
+        mailer.send(new_message(&to1)).await.unwrap();
+        mailer.send(new_message(&to2)).await.unwrap_err();
+        mailer.send(new_message(&to3)).await.unwrap();
+
+        let inboxes = mailer.inboxes.lock().await;
+        assert!(inboxes.contains_key(&to1));
+        assert!(!inboxes.contains_key(&to2));
+        assert!(inboxes.contains_key(&to3));
+    }
+
+    #[tokio::test]
+    pub async fn test_recorder_expect_one_inbox_ok() {
+        let to = EmailAddress::from("to@example.com");
+        let message = new_message(&to);
+        let exp_formatted = message.formatted();
+
+        let mailer = RecorderSmtpMailer::default();
+        mailer.send(message.clone()).await.unwrap();
+        mailer.send(message).await.unwrap();
+
+        let messages = mailer.expect_one_inbox(&to).await;
+        assert_eq!(
+            vec![exp_formatted.clone(), exp_formatted],
+            messages.iter().map(Message::formatted).collect::<Vec<Vec<u8>>>(),
+        );
+    }
+
+    #[test]
+    pub fn test_recorder_expect_one_inbox_too_many_recipients() {
+        #[tokio::main(flavor = "current_thread")]
+        async fn do_test() {
+            let to1 = EmailAddress::from("to1@example.com");
+            let to2 = EmailAddress::from("to2@example.com");
+
+            let mailer = RecorderSmtpMailer::default();
+            mailer.send(new_message(&to1)).await.unwrap();
+            mailer.send(new_message(&to2)).await.unwrap();
+
+            let _ = mailer.expect_one_inbox(&to1).await; // Will panic.
+        }
+        assert!(catch_unwind(do_test).is_err());
+    }
+
+    #[tokio::test]
+    pub async fn test_recorder_expect_one_message_ok() {
+        let to = EmailAddress::from("to@example.com");
+        let message = new_message(&to);
+        let exp_formatted = message.formatted();
+
+        let mailer = RecorderSmtpMailer::default();
+        mailer.send(message).await.unwrap();
+
+        assert_eq!(exp_formatted, mailer.expect_one_message(&to).await.formatted());
+    }
+
+    #[test]
+    pub fn test_recorder_expect_one_message_too_many_recipients() {
+        #[tokio::main(flavor = "current_thread")]
+        async fn do_test() {
+            let to1 = EmailAddress::from("to1@example.com");
+            let to2 = EmailAddress::from("to2@example.com");
+
+            let mailer = RecorderSmtpMailer::default();
+            mailer.send(new_message(&to1)).await.unwrap();
+            mailer.send(new_message(&to2)).await.unwrap();
+
+            let _ = mailer.expect_one_message(&to1).await; // Will panic.
+        }
+        assert!(catch_unwind(do_test).is_err());
+    }
+
+    #[test]
+    pub fn test_recorder_expect_one_message_too_many_messages() {
+        #[tokio::main(flavor = "current_thread")]
+        async fn do_test() {
+            let to = EmailAddress::from("to@example.com");
+
+            let mailer = RecorderSmtpMailer::default();
+            mailer.send(new_message(&to)).await.unwrap();
+            mailer.send(new_message(&to)).await.unwrap();
+
+            let _ = mailer.expect_one_message(&to).await; // Will panic.
+        }
+        assert!(catch_unwind(do_test).is_err());
     }
 }


### PR DESCRIPTION
This type was first added so that a service could provide a trait with high-level primitives to send email messages declaratively.  The idea was that services could then supply a mock messenger that captured the messages based on their "type".

This worked mostly OK but was overly complex.  In particular, this became problematic when trying to generalize authentication functionality as such code needs to send an email but the services cannot implement a trait for a type when they don't own either of them.

It's easier if we remove the whole idea of the "messenger" and instead make the services deal with the underlying "mailer" directly.  And to support this change, this commit provides new test utilities to extract messages captured from the mock recorder mailer.