### PR TITLE
Add a basic authentication API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
     "lettre",
     "queue",
 ]
+resolver = "2"

--- a/authn/Cargo.toml
+++ b/authn/Cargo.toml
@@ -7,15 +7,38 @@ edition = "2021"
 publish = false
 
 [features]
+default = ["postgres"]
+postgres = ["iii-iv-core/postgres", "sqlx/postgres"]
+sqlite = ["dep:futures", "iii-iv-core/sqlite", "sqlx/sqlite"]
 testutils = []
 
 [dependencies]
+async-trait = "0.1"
+axum = "0.6"
 base64 = "0.21"
 bcrypt = "0.14"
+derivative = "2.2"
+futures = { version = "0.3", optional = true }
 rand = "0.8"
 http = "0.2.8"
 iii-iv-core = { path = "../core" }
+iii-iv-lettre = { path = "../lettre" }
 serde = { version = "1", features = ["derive"] }
+serde_urlencoded = "0.7"
+time = "0.3"
+
+[dependencies.sqlx]
+version = "0.7"
+optional = true
+features = ["runtime-tokio-rustls", "time"]
 
 [dev-dependencies]
-iii-iv-core = { path = "../core", features = ["testutils"] }
+futures = "0.3"
+iii-iv-core = { path = "../core", features = ["sqlite", "testutils"] }
+iii-iv-lettre = { path = "../lettre", features = ["testutils"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+url = "2.3"
+
+[dev-dependencies.sqlx]
+version = "0.7"
+features = ["runtime-tokio-rustls", "sqlite", "time"]

--- a/authn/Cargo.toml
+++ b/authn/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 default = ["postgres"]
 postgres = ["iii-iv-core/postgres", "sqlx/postgres"]
 sqlite = ["dep:futures", "iii-iv-core/sqlite", "sqlx/sqlite"]
-testutils = ["dep:url"]
+testutils = ["dep:url", "iii-iv-core/sqlite", "iii-iv-core/testutils", "iii-iv-lettre/testutils"]
 
 [dependencies]
 async-trait = "0.1"

--- a/authn/Cargo.toml
+++ b/authn/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 default = ["postgres"]
 postgres = ["iii-iv-core/postgres", "sqlx/postgres"]
 sqlite = ["dep:futures", "iii-iv-core/sqlite", "sqlx/sqlite"]
-testutils = []
+testutils = ["dep:url"]
 
 [dependencies]
 async-trait = "0.1"
@@ -26,6 +26,7 @@ iii-iv-lettre = { path = "../lettre" }
 serde = { version = "1", features = ["derive"] }
 serde_urlencoded = "0.7"
 time = "0.3"
+url = { version = "2.3", optional = true }
 
 [dependencies.sqlx]
 version = "0.7"

--- a/authn/functions/activate/function.json
+++ b/authn/functions/activate/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"
+      ],
+      "route": "users/{user:regex(^[^/]+$)}/activate"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/authn/functions/login/function.json
+++ b/authn/functions/login/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "post"
+      ],
+      "route": "login"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/authn/functions/logout/function.json
+++ b/authn/functions/logout/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "post"
+      ],
+      "route": "users/{user:regex(^[^/]+$)}/logout"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/authn/functions/signup/function.json
+++ b/authn/functions/signup/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "post"
+      ],
+      "route": "signup"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/authn/src/db/mod.rs
+++ b/authn/src/db/mod.rs
@@ -143,9 +143,9 @@ impl TryFrom<SqliteRow> for User {
     }
 }
 
-/// Creates a new user named `username`, with a `password` in hashed form, an `email` address.
+/// Creates a new user named `username`, with a `password` in hashed form and an `email` address.
 /// The user is created as activated (no activation code) and as not having logged in.
-pub(crate) async fn create_user(
+pub async fn create_user(
     ex: &mut Executor,
     username: Username,
     password: Option<HashedPassword>,

--- a/authn/src/db/mod.rs
+++ b/authn/src/db/mod.rs
@@ -1,0 +1,477 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Database abstraction to manipulate users and authentication.
+
+use crate::model::{AccessToken, HashedPassword, Session, User};
+#[cfg(feature = "postgres")]
+use iii_iv_core::db::postgres;
+#[cfg(any(feature = "sqlite", test))]
+use iii_iv_core::db::sqlite::{self, build_timestamp, unpack_timestamp};
+use iii_iv_core::db::{DbError, DbResult, Executor};
+use iii_iv_core::model::{EmailAddress, Username};
+#[cfg(feature = "postgres")]
+use sqlx::postgres::PgRow;
+#[cfg(any(feature = "sqlite", test))]
+use sqlx::sqlite::SqliteRow;
+use sqlx::Row;
+use time::OffsetDateTime;
+
+#[cfg(test)]
+mod tests;
+
+/// Initializes the database schema.
+pub async fn init_schema(ex: &mut Executor) -> DbResult<()> {
+    match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            postgres::run_schema(ex, include_str!("postgres.sql")).await
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => sqlite::run_schema(ex, include_str!("sqlite.sql")).await,
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    }
+}
+
+/// Converts an `i32` extracted from the database to an `u32`.
+fn i32_to_u32(field: &'static str, signed: i32) -> DbResult<u32> {
+    if signed < 0 {
+        return Err(DbError::BackendError(format!("{} ({}) cannot be negative", field, signed)));
+    }
+    Ok(signed as u32)
+}
+
+/// Converts an `u32` from the in-memory model to an `i32` suitable for storage.
+fn u32_to_i32(field: &'static str, unsigned: u32) -> DbResult<i32> {
+    if unsigned > i32::MAX as u32 {
+        return Err(DbError::BackendError(format!(
+            "{} ({}) is too large for i32",
+            field, unsigned
+        )));
+    }
+    Ok(unsigned as i32)
+}
+
+#[cfg(feature = "postgres")]
+impl TryFrom<PgRow> for Session {
+    type Error = DbError;
+
+    fn try_from(row: PgRow) -> DbResult<Self> {
+        let access_token: String = row.try_get("access_token").map_err(postgres::map_sqlx_error)?;
+        let username: String = row.try_get("username").map_err(postgres::map_sqlx_error)?;
+        let login_time: OffsetDateTime =
+            row.try_get("login_time").map_err(postgres::map_sqlx_error)?;
+
+        let access_token = AccessToken::new(access_token)?;
+        let username = Username::new(username)?;
+
+        Ok(Session::new(access_token, username, login_time))
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl TryFrom<PgRow> for User {
+    type Error = DbError;
+
+    fn try_from(row: PgRow) -> DbResult<Self> {
+        let username: String = row.try_get("username").map_err(postgres::map_sqlx_error)?;
+        let password: Option<String> = row.try_get("password").map_err(postgres::map_sqlx_error)?;
+        let email: String = row.try_get("email").map_err(postgres::map_sqlx_error)?;
+        let activation_code: Option<i32> =
+            row.try_get("activation_code").map_err(postgres::map_sqlx_error)?;
+        let last_login: Option<OffsetDateTime> =
+            row.try_get("last_login").map_err(postgres::map_sqlx_error)?;
+
+        let activation_code = match activation_code {
+            Some(code) => Some(i32_to_u32("activation_code", code)?),
+            None => None,
+        };
+
+        let mut user = User::new(Username::new(username)?, EmailAddress::new(email)?)
+            .with_activation_code(activation_code);
+        if let Some(password) = password {
+            user = user.with_password(HashedPassword::new(password));
+        }
+        if let Some(last_login) = last_login {
+            user = user.with_last_login(last_login);
+        }
+        Ok(user)
+    }
+}
+
+#[cfg(any(feature = "sqlite", test))]
+impl TryFrom<SqliteRow> for Session {
+    type Error = DbError;
+
+    fn try_from(row: SqliteRow) -> DbResult<Self> {
+        let access_token: String = row.try_get("access_token").map_err(sqlite::map_sqlx_error)?;
+        let username: String = row.try_get("username").map_err(sqlite::map_sqlx_error)?;
+        let login_time_secs: i64 =
+            row.try_get("login_time_secs").map_err(sqlite::map_sqlx_error)?;
+        let login_time_nsecs: i64 =
+            row.try_get("login_time_nsecs").map_err(sqlite::map_sqlx_error)?;
+
+        let access_token = AccessToken::new(access_token)?;
+        let username = Username::new(username)?;
+        let login_time = build_timestamp(login_time_secs, login_time_nsecs)?;
+
+        Ok(Session::new(access_token, username, login_time))
+    }
+}
+
+#[cfg(any(feature = "sqlite", test))]
+impl TryFrom<SqliteRow> for User {
+    type Error = DbError;
+
+    fn try_from(row: SqliteRow) -> DbResult<Self> {
+        let username: String = row.try_get("username").map_err(sqlite::map_sqlx_error)?;
+        let password: Option<String> = row.try_get("password").map_err(sqlite::map_sqlx_error)?;
+        let email: String = row.try_get("email").map_err(sqlite::map_sqlx_error)?;
+        let activation_code: Option<u32> =
+            row.try_get("activation_code").map_err(sqlite::map_sqlx_error)?;
+        let last_login_secs: Option<i64> =
+            row.try_get("last_login_secs").map_err(sqlite::map_sqlx_error)?;
+        let last_login_nsecs: Option<i64> =
+            row.try_get("last_login_nsecs").map_err(sqlite::map_sqlx_error)?;
+
+        let mut user = User::new(Username::new(username)?, EmailAddress::new(email)?)
+            .with_activation_code(activation_code);
+        if let Some(password) = password {
+            user = user.with_password(HashedPassword::new(password));
+        }
+        match (last_login_secs, last_login_nsecs) {
+            (Some(secs), Some(nsecs)) => user = user.with_last_login(build_timestamp(secs, nsecs)?),
+            (None, None) => (),
+            (_, _) => {
+                return Err(DbError::DataIntegrityError(
+                    "Inconsistent values for last_login".to_owned(),
+                ))
+            }
+        }
+        Ok(user)
+    }
+}
+
+/// Creates a new user named `username`, with a `password` in hashed form, an `email` address.
+/// The user is created as activated (no activation code) and as not having logged in.
+pub(crate) async fn create_user(
+    ex: &mut Executor,
+    username: Username,
+    password: Option<HashedPassword>,
+    email: EmailAddress,
+) -> DbResult<User> {
+    let rows_affected = match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str = "INSERT INTO users (username, password, email) VALUES ($1, $2, $3)";
+            let done = sqlx::query(query_str)
+                .bind(username.as_str())
+                .bind(password.as_ref().map(|x| Some(x.as_str())))
+                .bind(email.as_str())
+                .execute(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let query_str = "INSERT INTO users (username, password, email) VALUES (?, ?, ?)";
+            let done = sqlx::query(query_str)
+                .bind(username.as_str())
+                .bind(password.as_ref().map(|x| Some(x.as_str())))
+                .bind(email.as_str())
+                .execute(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    };
+
+    if rows_affected != 1 {
+        return Err(DbError::BackendError("Insertion affected more than one row".to_owned()));
+    }
+    let mut user = User::new(username, email);
+    if let Some(password) = password {
+        user = user.with_password(password);
+    }
+    Ok(user)
+}
+
+/// Gets information about an existing user named `username`.
+pub(crate) async fn get_user_by_username(ex: &mut Executor, username: Username) -> DbResult<User> {
+    match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str = "SELECT * FROM users WHERE username = $1";
+            let raw_user = sqlx::query(query_str)
+                .bind(username.as_str())
+                .fetch_one(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            User::try_from(raw_user)
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let query_str = "SELECT * FROM users WHERE username = ?";
+            let raw_user = sqlx::query(query_str)
+                .bind(username.as_str())
+                .fetch_one(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            User::try_from(raw_user)
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    }
+}
+
+/// Updates an existing user `username` to have new `last_login` details.
+pub(crate) async fn update_user(
+    ex: &mut Executor,
+    username: Username,
+    last_login: OffsetDateTime,
+) -> DbResult<()> {
+    let rows_affected = match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str = "UPDATE users SET last_login = $1 WHERE username = $2";
+            let done = sqlx::query(query_str)
+                .bind(last_login)
+                .bind(username.as_str())
+                .execute(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let (last_login_secs, last_login_nsecs) = unpack_timestamp(last_login);
+
+            let query_str = "
+                UPDATE users SET last_login_secs = ?, last_login_nsecs = ?
+                WHERE username = ?";
+            let done = sqlx::query(query_str)
+                .bind(last_login_secs)
+                .bind(last_login_nsecs)
+                .bind(username.as_str())
+                .execute(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    };
+
+    match rows_affected {
+        0 => Err(DbError::NotFound),
+        1 => Ok(()),
+        _ => Err(DbError::BackendError("Update affected more than one row".to_owned())),
+    }
+}
+
+/// Updates the activation code of an existing user, either to a new code or to nothing to
+/// indicate that the user is active.
+pub(crate) async fn set_user_activation_code(
+    ex: &mut Executor,
+    user: User,
+    code: Option<u32>,
+) -> DbResult<User> {
+    let rows_affected = match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let i32_code = match code {
+                Some(code) => Some(u32_to_i32("activation_code", code)?),
+                None => None,
+            };
+            let query_str = "UPDATE users SET activation_code = $1 WHERE username = $2";
+            let done = sqlx::query(query_str)
+                .bind(i32_code)
+                .bind(user.username().as_str())
+                .execute(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let query_str = "UPDATE users SET activation_code = ? WHERE username = ?";
+            let done = sqlx::query(query_str)
+                .bind(code)
+                .bind(user.username().as_str())
+                .execute(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    };
+
+    match rows_affected {
+        0 => Err(DbError::NotFound),
+        1 => Ok(user.with_activation_code(code)),
+        _ => Err(DbError::BackendError("Update affected more than one row".to_owned())),
+    }
+}
+
+/// Gets a session from its access token.  Sessions marked as deleted (logged out) are
+/// ignored.
+pub(crate) async fn get_session(
+    ex: &mut Executor,
+    access_token: &AccessToken,
+) -> DbResult<Session> {
+    match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str = "
+                SELECT access_token, username, login_time
+                FROM sessions
+                WHERE access_token = $1 AND logout_time IS NULL";
+            let raw_session = sqlx::query(query_str)
+                .bind(access_token.as_str())
+                .fetch_one(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            Session::try_from(raw_session)
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let query_str = "
+                SELECT access_token, username, login_time_secs, login_time_nsecs
+                FROM sessions
+                WHERE
+                    access_token = ? AND
+                    logout_time_secs IS NULL AND
+                    logout_time_nsecs IS NULL";
+            let raw_session = sqlx::query(query_str)
+                .bind(access_token.as_str())
+                .fetch_one(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            Session::try_from(raw_session)
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    }
+}
+
+/// Saves a session.
+pub(crate) async fn put_session(ex: &mut Executor, session: &Session) -> DbResult<()> {
+    let rows_affected = match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str =
+                "INSERT INTO sessions (access_token, username, login_time) VALUES ($1, $2, $3)";
+
+            let done = sqlx::query(query_str)
+                .bind(session.access_token().as_str())
+                .bind(session.username().as_str())
+                .bind(session.login_time())
+                .execute(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let (login_time_secs, login_time_nsecs) = unpack_timestamp(session.login_time());
+
+            let query_str = "
+                INSERT INTO sessions (access_token, username, login_time_secs, login_time_nsecs)
+                VALUES (?, ?, ?, ?)";
+            let done = sqlx::query(query_str)
+                .bind(session.access_token().as_str())
+                .bind(session.username().as_str())
+                .bind(login_time_secs)
+                .bind(login_time_nsecs)
+                .execute(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    };
+
+    if rows_affected != 1 {
+        return Err(DbError::BackendError("Insertion affected more than one row".to_owned()));
+    }
+    Ok(())
+}
+
+/// Marks a session as deleted.
+pub(crate) async fn delete_session(
+    ex: &mut Executor,
+    session: Session,
+    now: OffsetDateTime,
+) -> DbResult<()> {
+    let rows_affected = match ex {
+        #[cfg(feature = "postgres")]
+        Executor::Postgres(ref mut ex) => {
+            let query_str = "UPDATE sessions SET logout_time = $1 WHERE access_token = $2";
+            let done = sqlx::query(query_str)
+                .bind(now)
+                .bind(session.access_token().as_str())
+                .execute(ex)
+                .await
+                .map_err(postgres::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[cfg(any(feature = "sqlite", test))]
+        Executor::Sqlite(ref mut ex) => {
+            let (now_secs, now_nsecs) = unpack_timestamp(now);
+
+            let query_str = "
+                UPDATE sessions
+                SET logout_time_secs = ?, logout_time_nsecs = ?
+                WHERE access_token = ?";
+            let done = sqlx::query(query_str)
+                .bind(now_secs)
+                .bind(now_nsecs)
+                .bind(session.access_token().as_str())
+                .execute(ex)
+                .await
+                .map_err(sqlite::map_sqlx_error)?;
+            done.rows_affected()
+        }
+
+        #[allow(unused)]
+        _ => unreachable!(),
+    };
+
+    if rows_affected != 1 {
+        return Err(DbError::BackendError("UPDATE affected more than one row".to_owned()));
+    }
+    Ok(())
+}

--- a/authn/src/db/postgres.sql
+++ b/authn/src/db/postgres.sql
@@ -1,0 +1,44 @@
+-- III-IV
+-- Copyright 2023 Julio Merino
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License.  You may obtain a copy
+-- of the License at:
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+CREATE TABLE IF NOT EXISTS users (
+    -- The user's chosen username.
+    username VARCHAR(32) PRIMARY KEY NOT NULL,
+
+    -- The user's hashed password using the bcrypt algorithm.
+    -- May be null, in which case the user is denied login.
+    password VARCHAR(60),
+
+    -- The user's email address.
+    email VARCHAR(64) UNIQUE NOT NULL,
+
+    -- Activation code.  If present, the account has not been activated yet.
+    activation_code INT,
+
+    -- The user's last successful login timestamp.
+    last_login TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    access_token CHAR(256) PRIMARY KEY NOT NULL,
+
+    username VARCHAR(32) NOT NULL REFERENCES users (username),
+
+    login_time TIMESTAMPTZ NOT NULL,
+
+    -- Logout time, if known.  Sessions have a maximum validity time as enforced by the driver
+    -- but users can also explicitly log out.
+    logout_time TIMESTAMPTZ
+);

--- a/authn/src/db/postgres.sql
+++ b/authn/src/db/postgres.sql
@@ -25,7 +25,10 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(64) UNIQUE NOT NULL,
 
     -- Activation code.  If present, the account has not been activated yet.
-    activation_code INT,
+    --
+    -- Note that this is supposed to be an u64 so it can show up as negative when persisted
+    -- in the database.
+    activation_code BIGINT,
 
     -- The user's last successful login timestamp.
     last_login TIMESTAMPTZ

--- a/authn/src/db/sqlite.sql
+++ b/authn/src/db/sqlite.sql
@@ -1,0 +1,36 @@
+-- III-IV
+-- Copyright 2023 Julio Merino
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License.  You may obtain a copy
+-- of the License at:
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+    username TEXT PRIMARY KEY NOT NULL,
+    password TEXT,
+    email TEXT UNIQUE NOT NULL,
+    activation_code INTEGER,
+    last_login_secs INTEGER,
+    last_login_nsecs INTEGER,
+    CHECK ((last_login_secs IS NULL AND last_login_nsecs IS NULL)
+           OR (last_login_secs IS NOT NULL AND last_login_nsecs IS NOT NULL))
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    access_token TEXT PRIMARY KEY NOT NULL,
+    username TEXT NOT NULL REFERENCES users (username),
+    login_time_secs INTEGER NOT NULL,
+    login_time_nsecs INTEGER NOT NULL,
+    logout_time_secs INTEGER,
+    logout_time_nsecs INTEGER
+);

--- a/authn/src/db/tests.rs
+++ b/authn/src/db/tests.rs
@@ -1,0 +1,251 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Common tests for any database implementation.
+
+use crate::db::*;
+use crate::model::{AccessToken, HashedPassword, Session, User};
+use iii_iv_core::clocks::testutils::utc_datetime;
+use iii_iv_core::db::{DbError, Executor};
+use iii_iv_core::model::{EmailAddress, Username};
+
+/// Syntactic sugar to create a user with default settings given only its username.
+async fn create_simple_user(ex: &mut Executor, username: &'static str) -> User {
+    create_user(
+        ex,
+        Username::from(username),
+        None,
+        EmailAddress::new(format!("{}@example.com", username)).unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+async fn test_users_ok(ex: &mut Executor) {
+    let user = create_user(
+        ex,
+        Username::from("some-username"),
+        Some(HashedPassword::new("some-hash")),
+        EmailAddress::from("a@example.com"),
+    )
+    .await
+    .unwrap();
+
+    let exp_user = User::new(Username::from("some-username"), EmailAddress::from("a@example.com"))
+        .with_password(HashedPassword::new("some-hash"));
+    assert_eq!(exp_user, user);
+
+    let user1 = get_user_by_username(ex, Username::from("some-username")).await.unwrap();
+    assert_eq!(user, user1);
+}
+
+async fn test_users_not_found(ex: &mut Executor) {
+    assert_eq!(
+        DbError::NotFound,
+        get_user_by_username(ex, Username::from("some-username")).await.unwrap_err()
+    );
+}
+
+async fn test_user_corrupted_name(ex: &mut Executor) {
+    let invalid = Username::new_invalid("this@is!invalid");
+    create_user(ex, invalid.clone(), None, EmailAddress::from("a@example.com")).await.unwrap();
+    match get_user_by_username(ex, invalid).await.unwrap_err() {
+        DbError::DataIntegrityError(msg) if msg.contains("Unsupported character") => (),
+        e => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+async fn test_user_corrupted_email(ex: &mut Executor) {
+    let invalid = EmailAddress::new_invalid("this_is_invalid");
+    create_user(ex, Username::from("a"), None, invalid).await.unwrap();
+    match get_user_by_username(ex, Username::from("a")).await.unwrap_err() {
+        DbError::DataIntegrityError(msg) if msg.contains("valid address") => (),
+        e => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+async fn test_users_update_ok(ex: &mut Executor) {
+    create_user(
+        ex,
+        Username::from("some-username"),
+        Some(HashedPassword::new("some-hash")),
+        EmailAddress::from("a@example.com"),
+    )
+    .await
+    .unwrap();
+    update_user(ex, Username::from("some-username"), utc_datetime(2022, 4, 2, 5, 50, 10))
+        .await
+        .unwrap();
+
+    let exp_user = User::new(Username::from("some-username"), EmailAddress::from("a@example.com"))
+        .with_password(HashedPassword::new("some-hash"))
+        .with_last_login(utc_datetime(2022, 4, 2, 5, 50, 10));
+    assert_eq!(exp_user, get_user_by_username(ex, Username::from("some-username")).await.unwrap());
+}
+
+async fn test_users_update_not_found(ex: &mut Executor) {
+    match update_user(ex, Username::from("foo"), utc_datetime(2022, 4, 2, 6, 32, 0))
+        .await
+        .unwrap_err()
+    {
+        DbError::NotFound => (),
+        e => panic!("{}", e),
+    }
+
+    match get_user_by_username(ex, Username::from("foo")).await.unwrap_err() {
+        DbError::NotFound => (),
+        e => panic!("{}", e),
+    }
+}
+
+async fn test_set_user_activation_code_ok(ex: &mut Executor) {
+    let mut user = create_user(
+        ex,
+        Username::from("some-username"),
+        Some(HashedPassword::new("some-hash")),
+        EmailAddress::from("a@example.com"),
+    )
+    .await
+    .unwrap();
+    assert!(user.activation_code().is_none());
+
+    user = set_user_activation_code(ex, user, Some(123456)).await.unwrap();
+    assert_eq!(Some(123456), user.activation_code());
+
+    let read_user = get_user_by_username(ex, user.username().clone()).await.unwrap();
+    assert_eq!(Some(123456), read_user.activation_code());
+
+    user = set_user_activation_code(ex, user, None).await.unwrap();
+    assert!(user.activation_code().is_none());
+
+    let read_user = get_user_by_username(ex, user.username().clone()).await.unwrap();
+    assert!(read_user.activation_code().is_none());
+}
+
+async fn test_set_user_activation_code_not_found(ex: &mut Executor) {
+    let user = User::new(Username::from("foo"), EmailAddress::from("a@example.com"));
+
+    match set_user_activation_code(ex, user, Some(1)).await.unwrap_err() {
+        DbError::NotFound => (),
+        e => panic!("{}", e),
+    }
+
+    match get_user_by_username(ex, Username::from("foo")).await.unwrap_err() {
+        DbError::NotFound => (),
+        e => panic!("{}", e),
+    }
+}
+
+async fn test_sessions_ok(ex: &mut Executor) {
+    create_simple_user(ex, "testuser1").await;
+    let session1 = Session::new(
+        AccessToken::generate(),
+        Username::from("testuser1"),
+        utc_datetime(2022, 5, 17, 6, 29, 28),
+    );
+    put_session(ex, &session1).await.unwrap();
+
+    create_simple_user(ex, "testuser2").await;
+    let session2 = Session::new(
+        AccessToken::generate(),
+        Username::from("testuser1"),
+        utc_datetime(2022, 5, 17, 6, 29, 28),
+    );
+    put_session(ex, &session2).await.unwrap();
+
+    assert_eq!(session1, get_session(ex, session1.access_token()).await.unwrap());
+    assert_eq!(session2, get_session(ex, session2.access_token()).await.unwrap());
+
+    // Mark one of the sessions as deleted.
+    let access_token1 = session1.access_token().clone();
+    delete_session(ex, session1, utc_datetime(2022, 5, 26, 8, 38, 10)).await.unwrap();
+    match get_session(ex, &access_token1).await {
+        Err(DbError::NotFound) => (),
+        e => panic!("{:?}", e),
+    }
+
+    // Make sure the other session was unaffected.
+    assert_eq!(session2, get_session(ex, session2.access_token()).await.unwrap());
+}
+
+async fn test_sessions_missing(ex: &mut Executor) {
+    create_simple_user(ex, "testuser1").await;
+    let session = Session::new(
+        AccessToken::generate(),
+        Username::from("testuser1"),
+        utc_datetime(2022, 5, 17, 6, 29, 28),
+    );
+    put_session(ex, &session).await.unwrap();
+
+    match get_session(ex, &AccessToken::generate()).await {
+        Err(DbError::NotFound) => (),
+        e => panic!("{:?}", e),
+    }
+}
+
+macro_rules! generate_db_tests [
+    ( $setup:expr $(, #[$extra:meta] )? ) => {
+        iii_iv_core::db::testutils::generate_tests!(
+            $(#[$extra],)?
+            $setup,
+            $crate::db::tests,
+            test_users_ok,
+            test_users_not_found,
+            test_user_corrupted_name,
+            test_user_corrupted_email,
+            test_users_update_ok,
+            test_users_update_not_found,
+            test_set_user_activation_code_ok,
+            test_set_user_activation_code_not_found,
+            test_sessions_ok,
+            test_sessions_missing
+        );
+    }
+];
+
+use generate_db_tests;
+
+mod postgres {
+    use super::*;
+    use crate::db::init_schema;
+    use iii_iv_core::db::postgres::PostgresDb;
+    use iii_iv_core::db::Db;
+
+    async fn setup() -> PostgresDb {
+        let db = iii_iv_core::db::postgres::testutils::setup().await;
+        init_schema(&mut db.ex()).await.unwrap();
+        db
+    }
+
+    generate_db_tests!(
+        &mut setup().await.ex(),
+        #[ignore = "Requires environment configuration and is expensive"]
+    );
+}
+
+mod sqlite {
+    use super::*;
+    use crate::db::init_schema;
+    use iii_iv_core::db::sqlite::SqliteDb;
+    use iii_iv_core::db::Db;
+
+    async fn setup() -> SqliteDb {
+        let db = iii_iv_core::db::sqlite::testutils::setup().await;
+        init_schema(&mut db.ex()).await.unwrap();
+        db
+    }
+
+    generate_db_tests!(&mut setup().await.ex());
+}

--- a/authn/src/driver/activate.rs
+++ b/authn/src/driver/activate.rs
@@ -22,7 +22,7 @@ use iii_iv_core::model::Username;
 
 impl AuthnDriver {
     /// Marks a used as active based on a confirmation code.
-    pub(crate) async fn activate(self, username: Username, code: u32) -> DriverResult<()> {
+    pub(crate) async fn activate(self, username: Username, code: u64) -> DriverResult<()> {
         let mut tx = self.db.begin().await?;
 
         let user = db::get_user_by_username(tx.ex(), username).await?;
@@ -50,7 +50,7 @@ mod tests {
     use iii_iv_core::model::EmailAddress;
 
     /// Creates a test user with an optional activation `code` and returns its username.
-    async fn create_test_user(ex: &mut Executor, code: Option<u32>) -> Username {
+    async fn create_test_user(ex: &mut Executor, code: Option<u64>) -> Username {
         let username = Username::from("some-username");
 
         let user = db::create_user(ex, username.clone(), None, EmailAddress::from("a@example.com"))

--- a/authn/src/driver/activate.rs
+++ b/authn/src/driver/activate.rs
@@ -64,7 +64,7 @@ mod tests {
     #[tokio::test]
     async fn test_activate_ok() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = create_test_user(&mut ex, Some(42)).await;
 
@@ -77,7 +77,7 @@ mod tests {
     #[tokio::test]
     async fn test_activate_bad_code() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = create_test_user(&mut ex, Some(42)).await;
 
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn test_activate_already_active() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = create_test_user(&mut ex, None).await;
 
@@ -109,7 +109,7 @@ mod tests {
     #[tokio::test]
     async fn test_user_not_found() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("unknown");
 

--- a/authn/src/driver/activate.rs
+++ b/authn/src/driver/activate.rs
@@ -1,0 +1,123 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Extends the driver with the `activate` method.
+
+use crate::db;
+use crate::driver::AuthnDriver;
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::model::Username;
+
+impl AuthnDriver {
+    /// Marks a used as active based on a confirmation code.
+    pub(crate) async fn activate(self, username: Username, code: u32) -> DriverResult<()> {
+        let mut tx = self.db.begin().await?;
+
+        let user = db::get_user_by_username(tx.ex(), username).await?;
+        match user.activation_code() {
+            Some(exp_code) => {
+                if exp_code != code {
+                    return Err(DriverError::InvalidInput("Invalid activation code".to_owned()));
+                }
+            }
+            None => return Err(DriverError::InvalidInput("User is already active".to_owned())),
+        }
+
+        db::set_user_activation_code(tx.ex(), user, None).await?;
+        tx.commit().await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::testutils::*;
+    use iii_iv_core::db::Executor;
+    use iii_iv_core::model::EmailAddress;
+
+    /// Creates a test user with an optional activation `code` and returns its username.
+    async fn create_test_user(ex: &mut Executor, code: Option<u32>) -> Username {
+        let username = Username::from("some-username");
+
+        let user = db::create_user(ex, username.clone(), None, EmailAddress::from("a@example.com"))
+            .await
+            .unwrap();
+        db::set_user_activation_code(ex, user, code).await.unwrap();
+
+        username
+    }
+
+    #[tokio::test]
+    async fn test_activate_ok() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = create_test_user(&mut ex, Some(42)).await;
+
+        context.driver().activate(username.clone(), 42).await.unwrap();
+
+        let user = db::get_user_by_username(&mut ex, username).await.unwrap();
+        assert!(user.activation_code().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_activate_bad_code() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = create_test_user(&mut ex, Some(42)).await;
+
+        match context.driver().activate(username.clone(), 41).await {
+            Err(DriverError::InvalidInput(e)) => assert!(e.contains("Invalid activation code")),
+            e => panic!("{:?}", e),
+        }
+
+        let user = db::get_user_by_username(&mut ex, username).await.unwrap();
+        assert!(user.activation_code().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_activate_already_active() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = create_test_user(&mut ex, None).await;
+
+        match context.driver().activate(username.clone(), 1234).await {
+            Err(DriverError::InvalidInput(e)) => assert!(e.contains("already active")),
+            e => panic!("{:?}", e),
+        }
+
+        let user = db::get_user_by_username(&mut ex, username).await.unwrap();
+        assert!(user.activation_code().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_user_not_found() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("unknown");
+
+        match context.driver().activate(username.clone(), 1234).await {
+            Err(DriverError::NotFound(_)) => (),
+            e => panic!("{:?}", e),
+        }
+
+        db::get_user_by_username(&mut ex, username).await.unwrap_err();
+    }
+}

--- a/authn/src/driver/email.rs
+++ b/authn/src/driver/email.rs
@@ -30,7 +30,7 @@ pub(super) async fn send_activation_code(
     base_urls: &BaseUrls,
     username: &Username,
     email: &EmailAddress,
-    code: u32,
+    code: u64,
 ) -> DriverResult<()> {
     // TODO(jmmv): This doesn't really belong here because it's leaking details about the REST
     // router into the driver.
@@ -85,7 +85,7 @@ pub(crate) mod testutils {
         mailer: &RecorderSmtpMailer,
         to: &EmailAddress,
         exp_username: &Username,
-    ) -> Option<u32> {
+    ) -> Option<u64> {
         let activation_url = get_latest_activation_url(mailer, to, exp_username).await;
         activation_url.map(|url| {
             url.as_str()

--- a/authn/src/driver/email.rs
+++ b/authn/src/driver/email.rs
@@ -1,0 +1,131 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Utilities to send canned messages to users over email.
+
+use crate::driver::DriverResult;
+use iii_iv_core::model::{EmailAddress, Username};
+use iii_iv_core::rest::BaseUrls;
+use iii_iv_lettre::{EmailTemplate, SmtpMailer};
+
+/// Sends the activation code `code` for `username` to the given `email` address.
+///
+/// The email contents are constructed from the `template` and are sent via `mailer`.
+/// `base_urls` is used to compute the address to the account activation endpoint.
+pub(super) async fn send_activation_code(
+    mailer: &(dyn SmtpMailer + Send + Sync),
+    template: &EmailTemplate,
+    base_urls: &BaseUrls,
+    username: &Username,
+    email: &EmailAddress,
+    code: u32,
+) -> DriverResult<()> {
+    // TODO(jmmv): This doesn't really belong here because it's leaking details about the REST
+    // router into the driver.
+    let activate_url = base_urls.make_backend_url(&format!(
+        "api/users/{}/activate?code={}",
+        username.as_str(),
+        code
+    ));
+
+    let replacements = [("activate_url", activate_url.as_str()), ("username", username.as_str())];
+    let message = template.apply(email, &replacements)?;
+
+    mailer.send(message).await
+}
+
+#[cfg(test)]
+pub(crate) mod testutils {
+    use super::*;
+    use iii_iv_lettre::testutils::{parse_message, RecorderSmtpMailer};
+    use url::Url;
+
+    pub(crate) fn make_test_activation_template() -> EmailTemplate {
+        let from = "from@example.com".parse().unwrap();
+        EmailTemplate { from, subject_template: "Test activation", body_template: "%activate_url%" }
+    }
+
+    /// Gets the latest activation URL sent to `to` which, if any, should be for the username
+    /// given in `exp_username`.
+    pub(crate) async fn get_latest_activation_url(
+        mailer: &RecorderSmtpMailer,
+        to: &EmailAddress,
+        exp_username: &Username,
+    ) -> Option<Url> {
+        let inboxes = mailer.inboxes.lock().await;
+        match inboxes.get(to) {
+            Some(inbox) => {
+                let message = inbox.last().expect("Must have received at least one message");
+                let (headers, body) = parse_message(message);
+                let bad_message = "Email was not built by make_test_activation_template";
+                assert_eq!("Test activation", headers.get("Subject").expect(bad_message));
+                let url = Url::parse(&body).expect(bad_message);
+                assert!(url.as_str().contains(&format!("api/users/{}/", exp_username.as_str())));
+                Some(url)
+            }
+            None => None,
+        }
+    }
+
+    /// Gets the latest activation code sent to `to` which, if any, should be for the username
+    /// given in `exp_username`.
+    pub(crate) async fn get_latest_activation_code(
+        mailer: &RecorderSmtpMailer,
+        to: &EmailAddress,
+        exp_username: &Username,
+    ) -> Option<u32> {
+        let activation_url = get_latest_activation_url(mailer, to, exp_username).await;
+        activation_url.map(|url| {
+            url.as_str()
+                .split_once('=')
+                .map(|(_, code)| {
+                    str::parse(code).expect("Want only one numerical parameter in query string")
+                })
+                .expect("No parameter found in query string")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testutils::*;
+    use super::*;
+    use iii_iv_lettre::testutils::*;
+
+    #[tokio::test]
+    async fn test_send_activation_code() {
+        let mailer = RecorderSmtpMailer::default();
+
+        let to = EmailAddress::from("user@example.com");
+        send_activation_code(
+            &mailer,
+            &make_test_activation_template(),
+            &BaseUrls::from_strs(
+                "https://test.example.com:1234/",
+                Some("https://no-frontend.example.com"),
+            ),
+            &Username::from("user-123"),
+            &to,
+            7654,
+        )
+        .await
+        .unwrap();
+
+        let message = mailer.expect_one_message(&to).await;
+        let (headers, body) = parse_message(&message);
+        assert_eq!(to.as_str(), headers.get("To").unwrap());
+        assert_eq!("https://test.example.com:1234/api/users/user-123/activate?code=7654", body);
+    }
+}

--- a/authn/src/driver/email.rs
+++ b/authn/src/driver/email.rs
@@ -46,12 +46,15 @@ pub(super) async fn send_activation_code(
     mailer.send(message).await
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testutils"))]
 pub(crate) mod testutils {
+    //! Utilities to help testing services that integrate with the `authn` features.
+
     use super::*;
     use iii_iv_lettre::testutils::{parse_message, RecorderSmtpMailer};
     use url::Url;
 
+    /// Creates an email activation template to capture activation codes during tests.
     pub(crate) fn make_test_activation_template() -> EmailTemplate {
         let from = "from@example.com".parse().unwrap();
         EmailTemplate { from, subject_template: "Test activation", body_template: "%activate_url%" }

--- a/authn/src/driver/login.rs
+++ b/authn/src/driver/login.rs
@@ -74,7 +74,7 @@ mod tests {
     #[tokio::test]
     async fn test_login_ok_first_time() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
         let password = Password::from("password");
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn test_login_ok_returning() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
         let password = Password::from("password");
@@ -145,7 +145,7 @@ mod tests {
     #[tokio::test]
     async fn test_login_invalid_password() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
 
@@ -167,7 +167,7 @@ mod tests {
     #[tokio::test]
     async fn test_login_not_allowed() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
 
@@ -184,7 +184,7 @@ mod tests {
     #[tokio::test]
     async fn test_login_not_activated() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
         let password = Password::from("password");

--- a/authn/src/driver/login.rs
+++ b/authn/src/driver/login.rs
@@ -1,0 +1,207 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Extends the driver with the `login` method.
+
+use crate::db;
+use crate::driver::AuthnDriver;
+use crate::model::{AccessToken, Password, Session};
+use iii_iv_core::db::DbError;
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::model::Username;
+
+impl AuthnDriver {
+    /// Logs a user with `username` and `password`.
+    pub(crate) async fn login(
+        self,
+        username: Username,
+        password: Password,
+    ) -> DriverResult<Session> {
+        let mut tx = self.db.begin().await?;
+        let now = self.clock.now_utc();
+
+        let user = match db::get_user_by_username(tx.ex(), username.clone()).await {
+            Ok(user) => user,
+            Err(DbError::NotFound) => {
+                return Err(DriverError::Unauthorized("Unknown user".to_owned()));
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        match user.password() {
+            Some(hash) => {
+                if !password.verify(hash)? {
+                    return Err(DriverError::Unauthorized("Invalid password".to_owned()));
+                }
+            }
+            None => return Err(DriverError::Unauthorized("Login not allowed".to_owned())),
+        };
+
+        if user.activation_code().is_some() {
+            return Err(DriverError::NotActivated);
+        }
+
+        let access_token = AccessToken::generate();
+        let session = Session::new(access_token, username.clone(), now);
+        db::put_session(tx.ex(), &session).await?;
+
+        db::update_user(tx.ex(), username.clone(), now).await?;
+
+        tx.commit().await.unwrap();
+        Ok(session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::testutils::*;
+    use iii_iv_core::model::EmailAddress;
+    use time::OffsetDateTime;
+
+    #[tokio::test]
+    async fn test_login_ok_first_time() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+        let password = Password::from("password");
+
+        db::create_user(
+            &mut ex,
+            username.clone(),
+            Some(password.clone().validate_and_hash(|_| None).unwrap()),
+            EmailAddress::from("some@example.com"),
+        )
+        .await
+        .unwrap();
+
+        let before = context.driver().now_utc();
+        let response = context.driver().login(username.clone(), password).await.unwrap();
+        let after = context.driver().now_utc();
+
+        let session = db::get_session(&mut ex, response.access_token()).await.unwrap();
+        assert_eq!(&username, session.username());
+        assert!(session.login_time() >= before && session.login_time() <= after);
+        let user = db::get_user_by_username(&mut ex, username).await.unwrap();
+        assert!(user.last_login().unwrap() >= before && user.last_login().unwrap() <= after);
+        assert_eq!(&EmailAddress::from("some@example.com"), user.email());
+    }
+
+    #[tokio::test]
+    async fn test_login_ok_returning() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+        let password = Password::from("password");
+
+        db::create_user(
+            &mut ex,
+            username.clone(),
+            Some(password.clone().validate_and_hash(|_| None).unwrap()),
+            EmailAddress::from("some@example.com"),
+        )
+        .await
+        .unwrap();
+        db::update_user(&mut ex, username.clone(), OffsetDateTime::from_unix_timestamp(1).unwrap())
+            .await
+            .unwrap();
+
+        let before = context.driver().now_utc();
+        let response = context.driver().login(username.clone(), password).await.unwrap();
+        let after = context.driver().now_utc();
+
+        let session = db::get_session(&mut ex, response.access_token()).await.unwrap();
+        assert_eq!(&username, session.username());
+        assert!(session.login_time() >= before && session.login_time() <= after);
+        let user = db::get_user_by_username(&mut ex, username).await.unwrap();
+        assert!(user.last_login().unwrap() >= before && user.last_login().unwrap() <= after);
+        assert_eq!(&EmailAddress::from("some@example.com"), user.email());
+    }
+
+    #[tokio::test]
+    async fn test_login_unknown_user() {
+        let context = TestContext::setup().await;
+
+        match context.driver().login(Username::from("foo"), Password::from("bar")).await {
+            Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("Unknown user")),
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_login_invalid_password() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+
+        db::create_user(
+            &mut ex,
+            username.clone(),
+            Some(Password::new("ABC").unwrap().validate_and_hash(|_| None).unwrap()),
+            EmailAddress::from("some@example.com"),
+        )
+        .await
+        .unwrap();
+
+        match context.driver().login(username, Password::from("abc")).await {
+            Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("Invalid password")),
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_login_not_allowed() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+
+        db::create_user(&mut ex, username.clone(), None, EmailAddress::from("some@example.com"))
+            .await
+            .unwrap();
+
+        match context.driver().login(username, Password::from("irrelevant")).await {
+            Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("Login not allowed")),
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_login_not_activated() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+        let password = Password::from("password");
+
+        let user = db::create_user(
+            &mut ex,
+            username.clone(),
+            Some(password.clone().validate_and_hash(|_| None).unwrap()),
+            EmailAddress::from("some@example.com"),
+        )
+        .await
+        .unwrap();
+        db::set_user_activation_code(&mut ex, user, Some(50)).await.unwrap();
+
+        match context.driver().login(username, password).await {
+            Err(DriverError::NotActivated) => (),
+            e => panic!("{:?}", e),
+        }
+    }
+}

--- a/authn/src/driver/logout.rs
+++ b/authn/src/driver/logout.rs
@@ -1,0 +1,92 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Extends the driver with the `logout` method.
+
+use crate::db;
+use crate::driver::AuthnDriver;
+use crate::model::AccessToken;
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::model::Username;
+
+impl AuthnDriver {
+    /// Marks a session as deleted.
+    pub(crate) async fn logout(self, token: AccessToken, username: Username) -> DriverResult<()> {
+        let mut tx = self.db.begin().await?;
+        let now = self.clock.now_utc();
+
+        let session = db::get_session(tx.ex(), &token).await?;
+        if session.username() != &username {
+            return Err(DriverError::NotFound("Entity not found".to_owned()));
+        }
+        db::delete_session(tx.ex(), session, now).await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::testutils::*;
+    use iii_iv_core::db::DbError;
+
+    #[tokio::test]
+    async fn test_ok() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("test");
+
+        let token = context.do_test_login(username.clone()).await;
+        context.driver().logout(token.clone(), username).await.unwrap();
+
+        match db::get_session(&mut ex, &token).await {
+            Err(DbError::NotFound) => (),
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username1 = Username::from("test1");
+
+        let token1 = context.do_test_login(username1.clone()).await;
+        let token2 = context.do_test_login(Username::from("test2")).await;
+        context.driver().logout(token1.clone(), username1).await.unwrap();
+
+        db::get_session(&mut ex, &token1).await.unwrap_err();
+        db::get_session(&mut ex, &token2).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_invalid_user_error() {
+        let context = TestContext::setup().await;
+
+        let username1 = Username::from("test1");
+        let username2 = Username::from("test2");
+
+        let token1 = context.do_test_login(username1.clone()).await;
+        let err1 = context.driver().logout(token1.clone(), username2).await.unwrap_err();
+        context.driver().logout(token1.clone(), username1.clone()).await.unwrap();
+        let err2 = context.driver().logout(token1.clone(), username1).await.unwrap_err();
+
+        assert_eq!(err1, err2);
+    }
+}

--- a/authn/src/driver/logout.rs
+++ b/authn/src/driver/logout.rs
@@ -47,7 +47,7 @@ mod tests {
     #[tokio::test]
     async fn test_ok() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("test");
 
@@ -63,7 +63,7 @@ mod tests {
     #[tokio::test]
     async fn test_not_found() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username1 = Username::from("test1");
 

--- a/authn/src/driver/mod.rs
+++ b/authn/src/driver/mod.rs
@@ -33,8 +33,8 @@ pub(crate) mod email;
 mod login;
 mod logout;
 mod signup;
-#[cfg(test)]
-pub(crate) mod testutils;
+#[cfg(any(test, feature = "testutils"))]
+pub mod testutils;
 
 /// Default value for the `SESSION_MAX_AGE` setting when not specified.
 const DEFAULT_SESSION_MAX_AGE_SECONDS: u64 = 24 * 60 * 60;
@@ -179,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_session_ok() {
         let context = TestContext::setup().await;
-        let mut tx = context.db.begin().await.unwrap();
+        let mut tx = context.db().begin().await.unwrap();
 
         let token = context.do_test_login(Username::from("username")).await;
         assert!(context
@@ -192,7 +192,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_session_login_expired() {
         let context = TestContext::setup().await;
-        let mut tx = context.db.begin().await.unwrap();
+        let mut tx = context.db().begin().await.unwrap();
 
         let token = context.do_test_login(Username::from("username")).await;
         assert!(context
@@ -236,7 +236,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_session_login_future() {
         let context = TestContext::setup().await;
-        let mut tx = context.db.begin().await.unwrap();
+        let mut tx = context.db().begin().await.unwrap();
 
         let token = context.do_test_login(Username::from("username")).await;
         assert!(context

--- a/authn/src/driver/mod.rs
+++ b/authn/src/driver/mod.rs
@@ -1,0 +1,284 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Business logic for user authentication.
+
+use crate::db;
+use crate::model::{AccessToken, User};
+use derivative::Derivative;
+use iii_iv_core::clocks::Clock;
+use iii_iv_core::db::{Db, DbError, TxExecutor};
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::env::get_optional_var;
+use iii_iv_core::rest::BaseUrls;
+use iii_iv_lettre::{EmailTemplate, SmtpMailer};
+use std::sync::Arc;
+use std::time::Duration;
+use time::OffsetDateTime;
+
+mod activate;
+pub(crate) mod email;
+mod login;
+mod logout;
+mod signup;
+#[cfg(test)]
+pub(crate) mod testutils;
+
+/// Default value for the `SESSION_MAX_AGE` setting when not specified.
+const DEFAULT_SESSION_MAX_AGE_SECONDS: u64 = 24 * 60 * 60;
+
+/// Default value for the `SESSION_MAX_SKEW` setting when not specified.
+const DEFAULT_SESSION_MAX_SKEW_SECONDS: u64 = 60 * 60;
+
+/// Configuration options for the authentication driver.
+#[derive(Clone)]
+pub struct AuthnOptions {
+    /// The amount of time we consider sessions valid for.
+    pub session_max_age: Duration,
+
+    /// The amount of time we tolerate in clock skew when validating sessions.  We should never see
+    /// this, except if we end up serving requests from different machines and their clocks aren't
+    /// properly synchronized.
+    pub session_max_skew: Duration,
+}
+
+impl Default for AuthnOptions {
+    fn default() -> Self {
+        Self {
+            session_max_age: Duration::from_secs(DEFAULT_SESSION_MAX_AGE_SECONDS),
+            session_max_skew: Duration::from_secs(DEFAULT_SESSION_MAX_SKEW_SECONDS),
+        }
+    }
+}
+
+impl AuthnOptions {
+    /// Creates a new set of options from environment variables.
+    pub fn from_env(prefix: &str) -> Result<Self, String> {
+        Ok(Self {
+            session_max_age: get_optional_var::<Duration>(prefix, "SESSION_MAX_AGE")?
+                .unwrap_or_else(|| Duration::from_secs(DEFAULT_SESSION_MAX_AGE_SECONDS)),
+            session_max_skew: get_optional_var::<Duration>(prefix, "SESSION_MAX_SKEW")?
+                .unwrap_or_else(|| Duration::from_secs(DEFAULT_SESSION_MAX_SKEW_SECONDS)),
+        })
+    }
+}
+
+/// Business logic.
+///
+/// The public operations exposed by the driver are all "one shot": they start and commit a
+/// transaction, so it's incorrect for the caller to use two separate calls.  For this reason,
+/// these operations consume the driver in an attempt to minimize the possibility of executing
+/// two operations.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct AuthnDriver {
+    /// The database that the driver uses for persistence.
+    db: Arc<dyn Db + Send + Sync>,
+
+    /// Clock instance to obtain the current time.
+    clock: Arc<dyn Clock + Send + Sync>,
+
+    /// Service to send email notifications with.
+    mailer: Arc<dyn SmtpMailer + Send + Sync>,
+
+    /// Email template to use for activation emails.
+    activation_template: Arc<EmailTemplate>,
+
+    /// Base URLs of the running service.
+    base_urls: Arc<BaseUrls>,
+
+    /// Authentication realm to return to requests.
+    realm: &'static str,
+
+    /// Options for the authentication driver.
+    opts: AuthnOptions,
+}
+
+impl AuthnDriver {
+    /// Creates a new driver backed by the given dependencies.
+    pub fn new(
+        db: Arc<dyn Db + Send + Sync>,
+        clock: Arc<dyn Clock + Send + Sync>,
+        mailer: Arc<dyn SmtpMailer + Send + Sync>,
+        activation_template: EmailTemplate,
+        base_urls: Arc<BaseUrls>,
+        realm: &'static str,
+        opts: AuthnOptions,
+    ) -> Self {
+        Self {
+            db,
+            clock,
+            mailer,
+            activation_template: Arc::from(activation_template),
+            base_urls,
+            realm,
+            opts,
+        }
+    }
+
+    /// Obtains the current time from the driver.
+    #[cfg(test)]
+    pub(crate) fn now_utc(&self) -> OffsetDateTime {
+        self.clock.now_utc()
+    }
+
+    /// Gets the authentication realm.
+    pub(crate) fn realm(&self) -> &'static str {
+        self.realm
+    }
+
+    /// Decodes the session in `token`, validates it and returns the user that owns the session.
+    pub async fn get_session(
+        &self,
+        tx: &mut TxExecutor,
+        now: OffsetDateTime,
+        token: AccessToken,
+    ) -> DriverResult<User> {
+        let session = match db::get_session(tx.ex(), &token).await {
+            Ok(session) => session,
+            Err(DbError::NotFound) => {
+                return Err(DriverError::Unauthorized("Invalid session".to_owned()))
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        let whoami = db::get_user_by_username(tx.ex(), session.username().clone()).await?;
+
+        let login_time = session.login_time();
+        let expired = login_time < (now - self.opts.session_max_age);
+        let skew = login_time > (now + self.opts.session_max_skew);
+        if expired || skew {
+            return Err(DriverError::Unauthorized(
+                "Session expired; please log in again".to_owned(),
+            ));
+        }
+
+        Ok(whoami)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::driver::testutils::*;
+    use iii_iv_core::driver::DriverError;
+    use iii_iv_core::model::Username;
+    use time::OffsetDateTime;
+
+    #[tokio::test]
+    async fn test_get_session_ok() {
+        let context = TestContext::setup().await;
+        let mut tx = context.db.begin().await.unwrap();
+
+        let token = context.do_test_login(Username::from("username")).await;
+        assert!(context
+            .driver()
+            .get_session(&mut tx, OffsetDateTime::from_unix_timestamp(100000).unwrap(), token)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_session_login_expired() {
+        let context = TestContext::setup().await;
+        let mut tx = context.db.begin().await.unwrap();
+
+        let token = context.do_test_login(Username::from("username")).await;
+        assert!(context
+            .driver()
+            .get_session(
+                &mut tx,
+                OffsetDateTime::from_unix_timestamp(100000).unwrap(),
+                token.clone()
+            )
+            .await
+            .is_ok());
+
+        for i in [98000_i64, 100500, 180000].iter() {
+            assert!(context
+                .driver()
+                .get_session(
+                    &mut tx,
+                    OffsetDateTime::from_unix_timestamp(*i).unwrap(),
+                    token.clone()
+                )
+                .await
+                .is_ok());
+        }
+
+        for i in [0_i64, 90000, 200000].iter() {
+            match context
+                .driver()
+                .get_session(
+                    &mut tx,
+                    OffsetDateTime::from_unix_timestamp(*i).unwrap(),
+                    token.clone(),
+                )
+                .await
+            {
+                Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("expired")),
+                e => panic!("{:?}", e),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_session_login_future() {
+        let context = TestContext::setup().await;
+        let mut tx = context.db.begin().await.unwrap();
+
+        let token = context.do_test_login(Username::from("username")).await;
+        assert!(context
+            .driver()
+            .get_session(
+                &mut tx,
+                OffsetDateTime::from_unix_timestamp(100000).unwrap(),
+                token.clone()
+            )
+            .await
+            .is_ok());
+
+        assert!(context
+            .driver()
+            .get_session(
+                &mut tx,
+                OffsetDateTime::from_unix_timestamp(100500).unwrap(),
+                token.clone()
+            )
+            .await
+            .is_ok());
+
+        match context
+            .driver()
+            .get_session(
+                &mut tx,
+                OffsetDateTime::from_unix_timestamp(90000).unwrap(),
+                token.clone(),
+            )
+            .await
+        {
+            Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("expired")),
+            e => panic!("{:?}", e),
+        }
+
+        match context
+            .driver()
+            .get_session(&mut tx, OffsetDateTime::from_unix_timestamp(0).unwrap(), token)
+            .await
+        {
+            Err(DriverError::Unauthorized(msg)) => assert!(msg.contains("expired")),
+            e => panic!("{:?}", e),
+        }
+    }
+}

--- a/authn/src/driver/signup.rs
+++ b/authn/src/driver/signup.rs
@@ -22,8 +22,6 @@ use crate::model::Password;
 use iii_iv_core::db::DbError;
 use iii_iv_core::driver::{DriverError, DriverResult};
 use iii_iv_core::model::{EmailAddress, Username};
-use rand::Rng;
-use std::convert::TryFrom;
 
 /// Verifies that a password is sufficiently complex.
 // TODO(jmmv): This should be hidden via a trait and the user of this crate should be able to
@@ -50,19 +48,6 @@ fn password_validator(s: &str) -> Option<&'static str> {
     None
 }
 
-/// Generates a new activation code.
-// TODO(jmmv): Simplify by allowing any value and possibly widen to 64 bits.  This was done
-// because we want codes to be positive when displayed (thus they need to be unsigned) but
-// the database can only store signed integers.  The current database code enforces that the
-// codes must fit in an `i32`... but we needn't do that: we can simply accept negative values
-// for storage and get rid of all that complexity.
-fn new_activation_code() -> u32 {
-    let mut rng = rand::thread_rng();
-    let code = rng.gen_range(10_000_000..100_000_000);
-    let _unused = i32::try_from(code).expect("Generated codes must fit in i32");
-    code
-}
-
 impl AuthnDriver {
     /// Creates a new account for a user.
     pub(crate) async fn signup(
@@ -85,7 +70,7 @@ impl AuthnDriver {
             Err(e) => return Err(e.into()),
         };
 
-        let activation_code = new_activation_code();
+        let activation_code = rand::random::<u64>();
         let user = db::set_user_activation_code(tx.ex(), user, Some(activation_code)).await?;
 
         // TODO(jmmv): This should leverage the queue somehow, but we need to figure out how that
@@ -109,14 +94,6 @@ impl AuthnDriver {
 mod tests {
     use super::*;
     use crate::driver::testutils::*;
-
-    #[test]
-    fn test_new_activation_code_length() {
-        for _ in 0..1000 {
-            let code = new_activation_code();
-            assert_eq!(8, format!("{}", code).len());
-        }
-    }
 
     #[tokio::test]
     async fn test_signup_ok() {

--- a/authn/src/driver/signup.rs
+++ b/authn/src/driver/signup.rs
@@ -98,7 +98,7 @@ mod tests {
     #[tokio::test]
     async fn test_signup_ok() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
         let password = Password::from("sufficiently0complex");
@@ -122,7 +122,7 @@ mod tests {
     #[tokio::test]
     async fn test_signup_username_already_exists() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let username = Username::from("hello");
         let email = EmailAddress::from("other@example.com");
@@ -144,7 +144,7 @@ mod tests {
     #[tokio::test]
     async fn test_signup_email_already_exists() {
         let context = TestContext::setup().await;
-        let mut ex = context.db.ex();
+        let mut ex = context.db().ex();
 
         let email = EmailAddress::from("foo@example.com");
 

--- a/authn/src/driver/signup.rs
+++ b/authn/src/driver/signup.rs
@@ -1,0 +1,216 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Extends the driver with the `signup` method.
+
+use crate::db;
+use crate::driver::email::send_activation_code;
+use crate::driver::AuthnDriver;
+use crate::model::Password;
+use iii_iv_core::db::DbError;
+use iii_iv_core::driver::{DriverError, DriverResult};
+use iii_iv_core::model::{EmailAddress, Username};
+use rand::Rng;
+use std::convert::TryFrom;
+
+/// Verifies that a password is sufficiently complex.
+// TODO(jmmv): This should be hidden via a trait and the user of this crate should be able to
+// choose or supply their own validation rules.
+fn password_validator(s: &str) -> Option<&'static str> {
+    if s.as_bytes().len() < 8 {
+        return Some("Too short");
+    }
+
+    let mut alphabetic = false;
+    let mut numeric = false;
+    for ch in s.chars() {
+        if ch.is_alphabetic() {
+            alphabetic = true;
+        }
+        if ch.is_numeric() {
+            numeric = true;
+        }
+    }
+    if !alphabetic || !numeric {
+        return Some("Must contain letters and numbers");
+    }
+
+    None
+}
+
+/// Generates a new activation code.
+// TODO(jmmv): Simplify by allowing any value and possibly widen to 64 bits.  This was done
+// because we want codes to be positive when displayed (thus they need to be unsigned) but
+// the database can only store signed integers.  The current database code enforces that the
+// codes must fit in an `i32`... but we needn't do that: we can simply accept negative values
+// for storage and get rid of all that complexity.
+fn new_activation_code() -> u32 {
+    let mut rng = rand::thread_rng();
+    let code = rng.gen_range(10_000_000..100_000_000);
+    let _unused = i32::try_from(code).expect("Generated codes must fit in i32");
+    code
+}
+
+impl AuthnDriver {
+    /// Creates a new account for a user.
+    pub(crate) async fn signup(
+        self,
+        username: Username,
+        password: Password,
+        email: EmailAddress,
+    ) -> DriverResult<()> {
+        let mut tx = self.db.begin().await?;
+
+        let password = password.validate_and_hash(password_validator)?;
+
+        let user = match db::create_user(tx.ex(), username, Some(password), email).await {
+            Ok(user) => user,
+            Err(DbError::AlreadyExists) => {
+                return Err(DriverError::AlreadyExists(
+                    "Username or email address are already registered".to_owned(),
+                ));
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        let activation_code = new_activation_code();
+        let user = db::set_user_activation_code(tx.ex(), user, Some(activation_code)).await?;
+
+        // TODO(jmmv): This should leverage the queue somehow, but we need to figure out how that
+        // can be done while also supporting service-specific tasks.
+        send_activation_code(
+            self.mailer.as_ref(),
+            &self.activation_template,
+            &self.base_urls,
+            user.username(),
+            user.email(),
+            activation_code,
+        )
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::testutils::*;
+
+    #[test]
+    fn test_new_activation_code_length() {
+        for _ in 0..1000 {
+            let code = new_activation_code();
+            assert_eq!(8, format!("{}", code).len());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_signup_ok() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+        let password = Password::from("sufficiently0complex");
+        let email = EmailAddress::from("foo@example.com");
+
+        assert_eq!(
+            DbError::NotFound,
+            db::get_user_by_username(&mut ex, username.clone()).await.unwrap_err()
+        );
+
+        context.driver().signup(username.clone(), password, email).await.unwrap();
+
+        let user = db::get_user_by_username(&mut ex, username.clone()).await.unwrap();
+        assert!(user.activation_code().is_some());
+        assert_eq!(
+            user.activation_code(),
+            context.get_latest_activation_code(user.email(), &username).await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_signup_username_already_exists() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let username = Username::from("hello");
+        let email = EmailAddress::from("other@example.com");
+
+        db::create_user(&mut ex, username.clone(), None, email.clone()).await.unwrap();
+
+        match context
+            .driver()
+            .signup(username.clone(), Password::from("the1password"), email.clone())
+            .await
+        {
+            Err(DriverError::AlreadyExists(msg)) => assert!(msg.contains("already registered")),
+            e => panic!("{:?}", e),
+        }
+
+        assert!(context.get_latest_activation_code(&email, &username).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_signup_email_already_exists() {
+        let context = TestContext::setup().await;
+        let mut ex = context.db.ex();
+
+        let email = EmailAddress::from("foo@example.com");
+
+        db::create_user(&mut ex, Username::from("some"), None, email.clone()).await.unwrap();
+
+        match context
+            .driver()
+            .signup(Username::from("other"), Password::from("the1password"), email.clone())
+            .await
+        {
+            Err(DriverError::AlreadyExists(msg)) => assert!(msg.contains("already registered")),
+            e => panic!("{:?}", e),
+        }
+
+        assert!(context.get_latest_activation_code(&email, &Username::from("x")).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_signup_weak_password() {
+        let context = TestContext::setup().await;
+
+        let username = Username::from("hello");
+        let email = EmailAddress::from("other@example.com");
+
+        for (password, error) in [
+            ("a", "Too short"),
+            ("abcdefg", "Too short"),
+            ("long enough", "letters and numbers"),
+            ("1234567890", "letters and numbers"),
+        ] {
+            match context
+                .driver()
+                .signup(username.clone(), Password::new(password).unwrap(), email.clone())
+                .await
+            {
+                Err(DriverError::InvalidInput(msg)) => {
+                    assert!(msg.contains("Weak password"));
+                    assert!(msg.contains(error));
+                }
+                e => panic!("{:?}", e),
+            }
+
+            assert!(context.get_latest_activation_code(&email, &username).await.is_none());
+        }
+    }
+}

--- a/authn/src/driver/testutils.rs
+++ b/authn/src/driver/testutils.rs
@@ -86,7 +86,7 @@ impl TestContext {
         &self,
         email: &EmailAddress,
         exp_username: &Username,
-    ) -> Option<u32> {
+    ) -> Option<u64> {
         get_latest_activation_code(&self.mailer, email, exp_username).await
     }
 }

--- a/authn/src/driver/testutils.rs
+++ b/authn/src/driver/testutils.rs
@@ -1,0 +1,92 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use crate::db;
+use crate::driver::email::testutils::{get_latest_activation_code, make_test_activation_template};
+use crate::driver::{AuthnDriver, AuthnOptions};
+use crate::model::{AccessToken, Password};
+use iii_iv_core::clocks::testutils::MonotonicClock;
+use iii_iv_core::db::Db;
+use iii_iv_core::model::EmailAddress;
+use iii_iv_core::model::Username;
+use iii_iv_core::rest::BaseUrls;
+use iii_iv_lettre::testutils::RecorderSmtpMailer;
+use std::sync::Arc;
+
+/// State of a running test.
+pub(crate) struct TestContext {
+    pub(crate) db: Arc<dyn Db + Send + Sync>,
+    mailer: Arc<RecorderSmtpMailer>,
+    driver: AuthnDriver,
+}
+
+impl TestContext {
+    /// Initializes the driver using an in-memory database, a monotonic clock and a mock
+    /// messenger that captures outgoing notifications.
+    pub(crate) async fn setup() -> Self {
+        let db = Arc::from(iii_iv_core::db::sqlite::testutils::setup().await);
+        db::init_schema(&mut db.ex()).await.unwrap();
+        let clock = Arc::from(MonotonicClock::new(100000));
+        let mailer = Arc::from(RecorderSmtpMailer::default());
+        let base_urls = Arc::from(BaseUrls::from_strs(
+            "http://localhost:1234/",
+            Some("http://no-frontend.example.com"),
+        ));
+        let driver = AuthnDriver::new(
+            db.clone(),
+            clock,
+            mailer.clone(),
+            make_test_activation_template(),
+            base_urls,
+            "the-realm",
+            AuthnOptions::default(),
+        );
+
+        TestContext { db, mailer, driver }
+    }
+
+    /// Syntactic sugar to create and log a user in for testing purposes.
+    pub(crate) async fn do_test_login(&self, username: Username) -> AccessToken {
+        let password = Password::from("test0password");
+
+        let email = EmailAddress::new(format!("{}@example.com", username.as_str())).unwrap();
+        self.driver
+            .clone()
+            .signup(username.clone(), password.clone(), email.clone())
+            .await
+            .unwrap();
+        let activation_code =
+            get_latest_activation_code(&self.mailer, &email, &username).await.unwrap();
+        self.driver.clone().activate(username.clone(), activation_code).await.unwrap();
+
+        let response = self.driver.clone().login(username, password).await.unwrap();
+        response.take_access_token()
+    }
+
+    /// Gets a copy of the driver in this test context.
+    pub(crate) fn driver(&self) -> AuthnDriver {
+        self.driver.clone()
+    }
+
+    /// Gets the latest activation code sent to `email` which, if any, should be for the username
+    /// given in `exp_username`.
+    pub(crate) async fn get_latest_activation_code(
+        &self,
+        email: &EmailAddress,
+        exp_username: &Username,
+    ) -> Option<u32> {
+        get_latest_activation_code(&self.mailer, email, exp_username).await
+    }
+}

--- a/authn/src/lib.rs
+++ b/authn/src/lib.rs
@@ -20,5 +20,7 @@
 #![warn(unused, unused_extern_crates, unused_import_braces, unused_qualifications)]
 #![warn(unsafe_code)]
 
+pub mod db;
+pub mod driver;
 pub mod model;
 pub mod rest;

--- a/authn/src/model/accesstoken.rs
+++ b/authn/src/model/accesstoken.rs
@@ -102,15 +102,15 @@ mod tests {
     #[test]
     fn test_accesstoken_error_invalid_character() {
         let raw_token = "!".repeat(TOKEN_LENGTH);
-        AccessToken::new(&raw_token).unwrap_err();
+        AccessToken::new(raw_token).unwrap_err();
     }
 
     #[test]
     fn test_accesstoken_error_too_long() {
         let mut raw_token = "b".repeat(TOKEN_LENGTH);
-        AccessToken::new(&raw_token).unwrap();
+        AccessToken::new(raw_token.clone()).unwrap();
         raw_token.push('b');
-        AccessToken::new(&raw_token).unwrap_err();
+        AccessToken::new(raw_token).unwrap_err();
     }
 
     #[test]

--- a/authn/src/model/mod.rs
+++ b/authn/src/model/mod.rs
@@ -19,3 +19,7 @@ mod accesstoken;
 pub use accesstoken::AccessToken;
 mod passwords;
 pub use passwords::{HashedPassword, Password};
+mod session;
+pub use session::Session;
+mod user;
+pub use user::User;

--- a/authn/src/model/passwords.rs
+++ b/authn/src/model/passwords.rs
@@ -16,15 +16,13 @@
 //! The `Password` and `HashedPassword` data types.
 
 use iii_iv_core::model::{ModelError, ModelResult};
-use serde::Deserialize;
-#[cfg(any(test, feature = "testutils"))]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// An opaque type to hold a password, protecting it from leaking into logs.
-#[derive(Deserialize, PartialEq)]
+#[derive(Deserialize, PartialEq, Serialize)]
 #[serde(transparent)]
-#[cfg_attr(any(test, feature = "testutils"), derive(Clone, Serialize))]
+#[cfg_attr(any(test, feature = "testutils"), derive(Clone))]
 pub struct Password(String);
 
 impl Password {

--- a/authn/src/model/passwords.rs
+++ b/authn/src/model/passwords.rs
@@ -16,11 +16,15 @@
 //! The `Password` and `HashedPassword` data types.
 
 use iii_iv_core::model::{ModelError, ModelResult};
+use serde::Deserialize;
+#[cfg(any(test, feature = "testutils"))]
+use serde::Serialize;
 use std::fmt;
 
 /// An opaque type to hold a password, protecting it from leaking into logs.
-#[derive(PartialEq)]
-#[cfg_attr(any(test, feature = "testutils"), derive(Clone))]
+#[derive(Deserialize, PartialEq)]
+#[serde(transparent)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Clone, Serialize))]
 pub struct Password(String);
 
 impl Password {

--- a/authn/src/model/session.rs
+++ b/authn/src/model/session.rs
@@ -1,0 +1,82 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! The `Session` data type.
+
+use crate::model::AccessToken;
+use iii_iv_core::model::Username;
+use time::OffsetDateTime;
+
+/// Represents a user session.
+#[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+pub struct Session {
+    /// The access token for the session, which acts as its identifier.
+    access_token: AccessToken,
+
+    /// The username for this session.
+    username: Username,
+
+    /// Timestamp to represent when the session was initiated.
+    login_time: OffsetDateTime,
+}
+
+impl Session {
+    /// Creates a new session from its parts.
+    pub(crate) fn new(
+        access_token: AccessToken,
+        username: Username,
+        login_time: OffsetDateTime,
+    ) -> Self {
+        Self { access_token, username, login_time }
+    }
+
+    /// Returns the session's access token.
+    pub fn access_token(&self) -> &AccessToken {
+        &self.access_token
+    }
+
+    /// Returns the session's username.
+    pub fn username(&self) -> &Username {
+        &self.username
+    }
+
+    /// Returns the session's login time.
+    pub fn login_time(&self) -> OffsetDateTime {
+        self.login_time
+    }
+
+    /// Consumes the session and extracts its access token.
+    pub(crate) fn take_access_token(self) -> AccessToken {
+        self.access_token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iii_iv_core::clocks::testutils::utc_datetime;
+
+    #[test]
+    fn test_session() {
+        let token = AccessToken::generate();
+        let username = Username::new("foo").unwrap();
+        let login_time = utc_datetime(2022, 5, 17, 6, 46, 53);
+        let session = Session::new(token.clone(), username.clone(), login_time);
+        assert_eq!(&token, session.access_token());
+        assert_eq!(&username, session.username());
+        assert_eq!(login_time, session.login_time());
+        assert_eq!(token, session.take_access_token());
+    }
+}

--- a/authn/src/model/user.rs
+++ b/authn/src/model/user.rs
@@ -1,0 +1,114 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! The `User` data type.
+
+use crate::model::HashedPassword;
+use iii_iv_core::model::{EmailAddress, Username};
+use time::OffsetDateTime;
+
+/// Representation of a user's information.
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct User {
+    /// Name of the user.
+    username: Username,
+
+    /// Hashed password.  None if the user is not allowed to log in.
+    password: Option<HashedPassword>,
+
+    /// Email of the user.
+    email: EmailAddress,
+
+    /// Token required to activate the user if not active yet.
+    activation_code: Option<u32>,
+
+    /// Time of last login of the user.  None if the user has never logged in.
+    last_login: Option<OffsetDateTime>,
+}
+
+impl User {
+    /// Creates a new user with the given fields.
+    pub(crate) fn new(username: Username, email: EmailAddress) -> Self {
+        Self { username, password: None, email, activation_code: None, last_login: None }
+    }
+
+    /// Modifies a user to set or clear its activation code.
+    pub(crate) fn with_activation_code(mut self, code: Option<u32>) -> Self {
+        self.activation_code = code;
+        self
+    }
+
+    /// Modifies a user to record their most recent login time.
+    pub(crate) fn with_last_login(mut self, last_login: OffsetDateTime) -> Self {
+        self.last_login = Some(last_login);
+        self
+    }
+
+    /// Modifies a user to add a password.
+    pub(crate) fn with_password(mut self, password: HashedPassword) -> Self {
+        self.password = Some(password);
+        self
+    }
+
+    /// Gets the user's username.
+    pub fn username(&self) -> &Username {
+        &self.username
+    }
+
+    /// Gets the user's password as a hash.
+    pub fn password(&self) -> Option<&HashedPassword> {
+        self.password.as_ref()
+    }
+
+    /// Gets the user's email address.
+    pub fn email(&self) -> &EmailAddress {
+        &self.email
+    }
+
+    /// Gets the user's activation code.
+    pub fn activation_code(&self) -> Option<u32> {
+        self.activation_code
+    }
+
+    /// Gets the user's last login timestamp, or `None` if the user has never logged in yet.
+    pub fn last_login(&self) -> Option<OffsetDateTime> {
+        self.last_login
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iii_iv_core::clocks::testutils::utc_datetime;
+
+    #[test]
+    fn test_user_getters() {
+        let user = User::new(Username::from("foo"), EmailAddress::from("a@example.com"));
+        assert_eq!(&Username::from("foo"), user.username());
+        assert!(user.password().is_none());
+        assert_eq!(&EmailAddress::from("a@example.com"), user.email());
+        assert!(user.activation_code().is_none());
+        assert!(user.last_login().is_none());
+
+        let user = user
+            .with_activation_code(Some(123))
+            .with_last_login(utc_datetime(2022, 4, 2, 5, 38, 0))
+            .with_password(HashedPassword::new("password-hash"));
+        assert_eq!(Some(123), user.activation_code());
+        assert_eq!(Some(&HashedPassword::new("password-hash")), user.password());
+        assert_eq!(Some(utc_datetime(2022, 4, 2, 5, 38, 0)), user.last_login());
+    }
+}

--- a/authn/src/model/user.rs
+++ b/authn/src/model/user.rs
@@ -33,7 +33,7 @@ pub struct User {
     email: EmailAddress,
 
     /// Token required to activate the user if not active yet.
-    activation_code: Option<u32>,
+    activation_code: Option<u64>,
 
     /// Time of last login of the user.  None if the user has never logged in.
     last_login: Option<OffsetDateTime>,
@@ -46,7 +46,7 @@ impl User {
     }
 
     /// Modifies a user to set or clear its activation code.
-    pub(crate) fn with_activation_code(mut self, code: Option<u32>) -> Self {
+    pub(crate) fn with_activation_code(mut self, code: Option<u64>) -> Self {
         self.activation_code = code;
         self
     }
@@ -79,7 +79,7 @@ impl User {
     }
 
     /// Gets the user's activation code.
-    pub fn activation_code(&self) -> Option<u32> {
+    pub fn activation_code(&self) -> Option<u64> {
         self.activation_code
     }
 

--- a/authn/src/rest/api_activate_get.rs
+++ b/authn/src/rest/api_activate_get.rs
@@ -43,7 +43,7 @@ const DEFAULT_ACTIVATED_TEMPLATE: &str = r#"<html>
 #[cfg_attr(test, derive(Serialize))]
 pub struct ActivateRequest {
     /// Activation code.
-    pub code: u32,
+    pub code: u64,
 }
 
 /// GET handler for this API.

--- a/authn/src/rest/api_activate_get.rs
+++ b/authn/src/rest/api_activate_get.rs
@@ -20,10 +20,23 @@ use axum::extract::{Path, Query, State};
 use axum::response::Html;
 use iii_iv_core::model::Username;
 use iii_iv_core::rest::{EmptyBody, RestError};
+use iii_iv_core::template;
 use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
-use std::fmt::Write;
+
+/// Default HTML to return when an account is successfully activated.
+const DEFAULT_ACTIVATED_TEMPLATE: &str = r#"<html>
+<head><title>Account activated</title></head>
+
+<body>
+<h1>Success!</h1>
+
+<p>%username%, your account has been successfully activated.</p>
+
+</body>
+</html>
+"#;
 
 /// Message sent to the server to activate a user account.
 #[derive(Default, Deserialize)]
@@ -34,8 +47,9 @@ pub struct ActivateRequest {
 }
 
 /// GET handler for this API.
+#[allow(clippy::type_complexity)]
 pub(crate) async fn handler(
-    State(driver): State<AuthnDriver>,
+    State((driver, activated_template)): State<(AuthnDriver, Option<&'static str>)>,
     Path(user): Path<String>,
     Query(request): Query<ActivateRequest>,
     _: EmptyBody,
@@ -44,16 +58,10 @@ pub(crate) async fn handler(
 
     driver.activate(user.clone(), request.code).await?;
 
-    // TODO(jmmv): Parameterize this so that clients can supply their own reponse
-    // to activation requests.
-    let mut body = String::new();
-    body += "<html><head><title>Account activated</title></head><body>";
-
-    body += "<h1>Success!</h1>";
-
-    write!(&mut body, "<p>{}, your account has been successfully activated.</p>", user.as_str())?;
-
-    body += "</body></html>";
+    let body = template::apply(
+        activated_template.unwrap_or(DEFAULT_ACTIVATED_TEMPLATE),
+        &[("username", user.as_str())],
+    );
 
     Ok(Html(body))
 }
@@ -91,6 +99,25 @@ mod tests {
 
         assert!(body.contains("Success"));
         assert!(body.contains(&format!("{}, your", context.whoami().as_str())));
+
+        assert!(context.user_is_active(user.username()).await);
+    }
+
+    #[tokio::test]
+    async fn test_ok_custom_template() {
+        let template = "All good, %username%!";
+        let mut context = TestContextBuilder::new().with_activated_template(template).build().await;
+
+        let user = context.create_inactive_whoami_user(8991).await;
+
+        let request = ActivateRequest { code: 8991 };
+        let body = OneShotBuilder::new(context.app(), route(user.username().as_str(), request))
+            .send_empty()
+            .await
+            .take_body_as_text()
+            .await;
+
+        assert_eq!(format!("All good, {}!", context.whoami().as_str()), body);
 
         assert!(context.user_is_active(user.username()).await);
     }

--- a/authn/src/rest/api_activate_get.rs
+++ b/authn/src/rest/api_activate_get.rs
@@ -1,0 +1,132 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! API to activate a newly-created user account.
+
+use crate::driver::AuthnDriver;
+use axum::extract::{Path, Query, State};
+use axum::response::Html;
+use iii_iv_core::model::Username;
+use iii_iv_core::rest::{EmptyBody, RestError};
+use serde::Deserialize;
+#[cfg(test)]
+use serde::Serialize;
+use std::fmt::Write;
+
+/// Message sent to the server to activate a user account.
+#[derive(Default, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
+pub struct ActivateRequest {
+    /// Activation code.
+    pub code: u32,
+}
+
+/// GET handler for this API.
+pub(crate) async fn handler(
+    State(driver): State<AuthnDriver>,
+    Path(user): Path<String>,
+    Query(request): Query<ActivateRequest>,
+    _: EmptyBody,
+) -> Result<Html<String>, RestError> {
+    let user = Username::new(user)?;
+
+    driver.activate(user.clone(), request.code).await?;
+
+    // TODO(jmmv): Parameterize this so that clients can supply their own reponse
+    // to activation requests.
+    let mut body = String::new();
+    body += "<html><head><title>Account activated</title></head><body>";
+
+    body += "<h1>Success!</h1>";
+
+    write!(&mut body, "<p>{}, your account has been successfully activated.</p>", user.as_str())?;
+
+    body += "</body></html>";
+
+    Ok(Html(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::testutils::*;
+    use axum::http;
+    use iii_iv_core::{rest::testutils::OneShotBuilder, test_payload_must_be_empty};
+
+    fn route(username: &str, query: ActivateRequest) -> (http::Method, String) {
+        (
+            http::Method::GET,
+            format!(
+                "/api/test/users/{}/activate?{}",
+                username,
+                serde_urlencoded::to_string(query).unwrap()
+            ),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        let user = context.create_inactive_whoami_user(8991).await;
+
+        let request = ActivateRequest { code: 8991 };
+        let body = OneShotBuilder::new(context.app(), route(user.username().as_str(), request))
+            .send_empty()
+            .await
+            .take_body_as_text()
+            .await;
+
+        assert!(body.contains("Success"));
+        assert!(body.contains(&format!("{}, your", context.whoami().as_str())));
+
+        assert!(context.user_is_active(user.username()).await);
+    }
+
+    #[tokio::test]
+    async fn test_cannot_activate() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        let user = context.create_inactive_whoami_user(8991).await;
+
+        let request = ActivateRequest { code: 123 };
+        OneShotBuilder::new(context.app(), route(user.username().as_str(), request))
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::BAD_REQUEST)
+            .expect_error("Invalid activation code")
+            .await;
+
+        assert!(!context.user_is_active(user.username()).await);
+    }
+
+    #[tokio::test]
+    async fn test_bad_username() {
+        let context = TestContextBuilder::new().build().await;
+
+        let request = ActivateRequest { code: 1 };
+        OneShotBuilder::new(context.into_app(), route("not%20valid", request))
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::BAD_REQUEST)
+            .expect_error("Unsupported character")
+            .await;
+    }
+
+    test_payload_must_be_empty!(
+        TestContextBuilder::new().build().await.into_app(),
+        route("irrelevant", ActivateRequest { code: 0 })
+    );
+}

--- a/authn/src/rest/api_activate_get.rs
+++ b/authn/src/rest/api_activate_get.rs
@@ -21,9 +21,7 @@ use axum::response::Html;
 use iii_iv_core::model::Username;
 use iii_iv_core::rest::{EmptyBody, RestError};
 use iii_iv_core::template;
-use serde::Deserialize;
-#[cfg(test)]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Default HTML to return when an account is successfully activated.
 const DEFAULT_ACTIVATED_TEMPLATE: &str = r#"<html>
@@ -39,8 +37,7 @@ const DEFAULT_ACTIVATED_TEMPLATE: &str = r#"<html>
 "#;
 
 /// Message sent to the server to activate a user account.
-#[derive(Default, Deserialize)]
-#[cfg_attr(test, derive(Serialize))]
+#[derive(Default, Deserialize, Serialize)]
 pub struct ActivateRequest {
     /// Activation code.
     pub code: u64,

--- a/authn/src/rest/api_login_post.rs
+++ b/authn/src/rest/api_login_post.rs
@@ -1,0 +1,108 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! API to create a new session for an existing user.
+
+use crate::driver::AuthnDriver;
+use crate::model::AccessToken;
+use crate::rest::get_basic_auth;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use axum::Json;
+use iii_iv_core::rest::{EmptyBody, RestError};
+#[cfg(test)]
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Message returned by the server after a successful login attempt.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
+pub(crate) struct LoginResponse {
+    /// Access token for this session.
+    pub(crate) access_token: AccessToken,
+}
+
+/// POST handler for this API.
+pub(crate) async fn handler(
+    State(driver): State<AuthnDriver>,
+    headers: HeaderMap,
+    _: EmptyBody,
+) -> Result<impl IntoResponse, RestError> {
+    let (username, password) = get_basic_auth(&headers, driver.realm())?;
+
+    let session = driver.login(username, password).await?;
+    let response = LoginResponse { access_token: session.take_access_token() };
+
+    Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::testutils::*;
+    use axum::http;
+    use iii_iv_core::rest::testutils::OneShotBuilder;
+    use iii_iv_core::test_payload_must_be_empty;
+
+    fn route() -> (http::Method, String) {
+        (http::Method::POST, "/api/test/login".to_owned())
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        context.create_whoami_user().await;
+
+        let response = OneShotBuilder::new(context.app(), route())
+            .with_basic_auth(context.whoami().as_str(), context.whoami_password().as_str())
+            .send_empty()
+            .await
+            .expect_json::<LoginResponse>()
+            .await;
+
+        assert!(context.session_exists(&response.access_token).await);
+        assert!(context.user_exists(&context.whoami()).await);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_user() {
+        let context = TestContextBuilder::new().build().await;
+
+        OneShotBuilder::new(context.app(), route())
+            .with_basic_auth(context.whoami().as_str(), "password")
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::FORBIDDEN)
+            .expect_error("Unknown user")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_bad_whoami() {
+        let context = TestContextBuilder::new().with_whoami("not%20valid").build().await;
+
+        OneShotBuilder::new(context.into_app(), route())
+            .with_basic_auth("not valid", "password")
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::BAD_REQUEST)
+            .expect_error("Unsupported character")
+            .await;
+    }
+
+    test_payload_must_be_empty!(TestContextBuilder::new().build().await.into_app(), route());
+}

--- a/authn/src/rest/api_login_post.rs
+++ b/authn/src/rest/api_login_post.rs
@@ -23,16 +23,13 @@ use axum::http::HeaderMap;
 use axum::response::IntoResponse;
 use axum::Json;
 use iii_iv_core::rest::{EmptyBody, RestError};
-#[cfg(test)]
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Message returned by the server after a successful login attempt.
-#[derive(Debug, Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
-pub(crate) struct LoginResponse {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LoginResponse {
     /// Access token for this session.
-    pub(crate) access_token: AccessToken,
+    pub access_token: AccessToken,
 }
 
 /// POST handler for this API.

--- a/authn/src/rest/api_logout_post.rs
+++ b/authn/src/rest/api_logout_post.rs
@@ -1,0 +1,103 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! API to terminate an existing session.
+
+use crate::driver::AuthnDriver;
+use crate::rest::get_bearer_auth;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use iii_iv_core::model::Username;
+use iii_iv_core::rest::{EmptyBody, RestError};
+
+/// POST handler for this API.
+pub(crate) async fn handler(
+    State(driver): State<AuthnDriver>,
+    Path(user): Path<Username>,
+    headers: HeaderMap,
+    _: EmptyBody,
+) -> Result<(), RestError> {
+    let access_token = get_bearer_auth(&headers, driver.realm())?;
+    driver.logout(access_token, user).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::AccessToken;
+    use crate::rest::testutils::*;
+    use axum::http;
+    use iii_iv_core::rest::testutils::OneShotBuilder;
+    use iii_iv_core::test_payload_must_be_empty;
+
+    fn route(username: &str) -> (http::Method, String) {
+        (http::Method::POST, format!("/api/test/users/{}/logout", username))
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        let user = context.create_whoami_user().await;
+        let token = context.access_token().await;
+
+        assert!(context.session_exists(&token).await);
+
+        OneShotBuilder::new(context.app(), route(user.username().as_str()))
+            .with_bearer_auth(token.as_str())
+            .send_empty()
+            .await
+            .expect_empty()
+            .await;
+
+        assert!(!context.session_exists(&token).await);
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        let user = context.create_whoami_user().await;
+        let token = AccessToken::generate();
+
+        OneShotBuilder::new(context.app(), route(user.username().as_str()))
+            .with_bearer_auth(token.as_str())
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::NOT_FOUND)
+            .expect_error("Entity not found")
+            .await;
+
+        assert!(!context.session_exists(&token).await);
+    }
+
+    #[tokio::test]
+    async fn test_bad_username() {
+        let context = TestContextBuilder::new().build().await;
+
+        OneShotBuilder::new(context.app(), route("not%20valid"))
+            .send_empty()
+            .await
+            .expect_status(http::StatusCode::BAD_REQUEST)
+            .expect_text("Unsupported character")
+            .await;
+    }
+
+    test_payload_must_be_empty!(
+        TestContextBuilder::new().build().await.into_app(),
+        route("irrelevant")
+    );
+}

--- a/authn/src/rest/api_signup_post.rs
+++ b/authn/src/rest/api_signup_post.rs
@@ -21,23 +21,20 @@ use axum::extract::State;
 use axum::Json;
 use iii_iv_core::model::{EmailAddress, Username};
 use iii_iv_core::rest::RestError;
-use serde::Deserialize;
-#[cfg(test)]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Message sent to the server to create an account.
-#[derive(Deserialize)]
-#[cfg_attr(test, derive(Serialize))]
-pub(crate) struct SignupRequest {
+#[derive(Deserialize, Serialize)]
+pub struct SignupRequest {
     /// Desired username.
-    pub(crate) username: Username,
+    pub username: Username,
 
     /// Desired password.
-    pub(crate) password: Password,
+    pub password: Password,
 
     /// Email address for the user, needed to validate their account signup process and to contact
     /// the user for service changes.
-    pub(crate) email: EmailAddress,
+    pub email: EmailAddress,
 }
 
 /// POST handler for this API.

--- a/authn/src/rest/api_signup_post.rs
+++ b/authn/src/rest/api_signup_post.rs
@@ -1,0 +1,132 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! API to create a new user account.
+
+use crate::driver::AuthnDriver;
+use crate::model::Password;
+use axum::extract::State;
+use axum::Json;
+use iii_iv_core::model::{EmailAddress, Username};
+use iii_iv_core::rest::RestError;
+use serde::Deserialize;
+#[cfg(test)]
+use serde::Serialize;
+
+/// Message sent to the server to create an account.
+#[derive(Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
+pub(crate) struct SignupRequest {
+    /// Desired username.
+    pub(crate) username: Username,
+
+    /// Desired password.
+    pub(crate) password: Password,
+
+    /// Email address for the user, needed to validate their account signup process and to contact
+    /// the user for service changes.
+    pub(crate) email: EmailAddress,
+}
+
+/// POST handler for this API.
+pub(crate) async fn handler(
+    State(driver): State<AuthnDriver>,
+    Json(request): Json<SignupRequest>,
+) -> Result<(), RestError> {
+    driver.signup(request.username, request.password, request.email).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::testutils::*;
+    use axum::http;
+    use iii_iv_core::{rest::testutils::OneShotBuilder, test_payload_must_be_json};
+
+    fn route() -> (http::Method, String) {
+        (http::Method::POST, "/api/test/signup".to_owned())
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        let request = SignupRequest {
+            username: "new".into(),
+            password: "hello4World".into(),
+            email: "new@example.com".into(),
+        };
+        OneShotBuilder::new(context.app(), route()).send_json(request).await.expect_empty().await;
+
+        assert!(context.user_exists(&Username::from("new")).await);
+        assert!(!context.user_is_active(&Username::from("new")).await);
+    }
+
+    #[tokio::test]
+    async fn test_already_exists() {
+        let mut context = TestContextBuilder::new().build().await;
+
+        context.create_whoami_user().await;
+
+        let request = SignupRequest {
+            username: context.whoami(),
+            password: "hello0World".into(),
+            email: "other@example.com".into(),
+        };
+        OneShotBuilder::new(context.into_app(), route())
+            .send_json(request)
+            .await
+            .expect_status(http::StatusCode::BAD_REQUEST)
+            .expect_error("already registered")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_bad_username() {
+        let context = TestContextBuilder::new().with_whoami("not valid").build().await;
+
+        let request = SignupRequest {
+            username: Username::new_invalid("not valid"),
+            password: "hello".into(),
+            email: "some@example.com".into(),
+        };
+        OneShotBuilder::new(context.into_app(), route())
+            .send_json(request)
+            .await
+            .expect_status(http::StatusCode::UNPROCESSABLE_ENTITY)
+            .expect_text("Unsupported character")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_bad_email() {
+        let context = TestContextBuilder::new().with_whoami("not valid").build().await;
+
+        let request = SignupRequest {
+            username: "valid".into(),
+            password: "hello".into(),
+            email: EmailAddress::new_invalid("some.example.com"),
+        };
+        OneShotBuilder::new(context.into_app(), route())
+            .send_json(request)
+            .await
+            .expect_status(http::StatusCode::UNPROCESSABLE_ENTITY)
+            .expect_text("Email.*valid address")
+            .await;
+    }
+
+    test_payload_must_be_json!(TestContextBuilder::new().build().await.into_app(), route());
+}

--- a/authn/src/rest/httputils.rs
+++ b/authn/src/rest/httputils.rs
@@ -1,5 +1,17 @@
 // III-IV
 // Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 
 //! Utilities to deal with HTTP authorization.
 

--- a/authn/src/rest/mod.rs
+++ b/authn/src/rest/mod.rs
@@ -1,0 +1,19 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! REST interface for a generic authorization service.
+
+mod httputils;
+pub use httputils::{get_basic_auth, get_bearer_auth, has_bearer_auth};

--- a/authn/src/rest/mod.rs
+++ b/authn/src/rest/mod.rs
@@ -26,6 +26,9 @@ mod httputils;
 #[cfg(test)]
 mod testutils;
 
+pub use api_activate_get::ActivateRequest;
+pub use api_login_post::LoginResponse;
+pub use api_signup_post::SignupRequest;
 pub use httputils::{get_basic_auth, get_bearer_auth, has_bearer_auth};
 
 /// Creates the router for the authentication endpoints.

--- a/authn/src/rest/mod.rs
+++ b/authn/src/rest/mod.rs
@@ -29,14 +29,24 @@ mod testutils;
 pub use httputils::{get_basic_auth, get_bearer_auth, has_bearer_auth};
 
 /// Creates the router for the authentication endpoints.
-pub fn app(driver: AuthnDriver) -> Router {
+///
+/// The `driver` is a configured instance of the `AuthnDriver` to handle accounts.
+///
+/// The `activated_template` HTML template is used when confirming the successful activation of
+/// a new account.
+pub fn app(driver: AuthnDriver, activated_template: Option<&'static str>) -> Router {
     use axum::routing::{get, post};
+
+    let activate_router = Router::new()
+        .route("/users/:user/activate", get(api_activate_get::handler))
+        .with_state((driver.clone(), activated_template));
+
     Router::new()
         .route("/login", post(api_login_post::handler))
-        .route("/users/:user/activate", get(api_activate_get::handler))
         .route("/users/:user/logout", post(api_logout_post::handler))
         .route("/signup", post(api_signup_post::handler))
         .with_state(driver)
+        .merge(activate_router)
 }
 
 #[cfg(test)]

--- a/authn/src/rest/mod.rs
+++ b/authn/src/rest/mod.rs
@@ -13,7 +13,125 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-//! REST interface for a generic authorization service.
+//! REST interface for a generic authentication service.
 
+use crate::driver::AuthnDriver;
+use axum::Router;
+
+mod api_activate_get;
+mod api_login_post;
+mod api_logout_post;
+mod api_signup_post;
 mod httputils;
+#[cfg(test)]
+mod testutils;
+
 pub use httputils::{get_basic_auth, get_bearer_auth, has_bearer_auth};
+
+/// Creates the router for the authentication endpoints.
+pub fn app(driver: AuthnDriver) -> Router {
+    use axum::routing::{get, post};
+    Router::new()
+        .route("/login", post(api_login_post::handler))
+        .route("/users/:user/activate", get(api_activate_get::handler))
+        .route("/users/:user/logout", post(api_logout_post::handler))
+        .route("/signup", post(api_signup_post::handler))
+        .with_state(driver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api_activate_get::ActivateRequest;
+    use super::api_login_post::LoginResponse;
+    use super::api_signup_post::SignupRequest;
+    use super::testutils::*;
+    use http::{Method, StatusCode};
+    use iii_iv_core::model::{EmailAddress, Username};
+    use iii_iv_core::rest::testutils::*;
+
+    #[tokio::test]
+    async fn test_e2e_signup_flow() {
+        let mut context = TestContextBuilder::new().with_whoami("the-user").build().await;
+
+        let request = SignupRequest {
+            username: "the-user".into(),
+            password: "The1234Password".into(),
+            email: "new@example.com".into(),
+        };
+        OneShotBuilder::new(context.app(), (Method::POST, "/api/test/signup"))
+            .send_json(request)
+            .await
+            .expect_empty()
+            .await;
+
+        OneShotBuilder::new(context.app(), (Method::POST, "/api/test/login"))
+            .with_basic_auth("the-user", "the password")
+            .send_empty()
+            .await
+            .expect_status(StatusCode::FORBIDDEN)
+            .expect_error("Invalid password")
+            .await;
+
+        OneShotBuilder::new(context.app(), (Method::POST, "/api/test/login"))
+            .with_basic_auth("the-user", "The1234Password")
+            .send_empty()
+            .await
+            .expect_status(StatusCode::CONFLICT)
+            .expect_error("Account.*not.*activated")
+            .await;
+
+        let request = ActivateRequest {
+            code: context
+                .get_latest_activation_code(
+                    &EmailAddress::from("new@example.com"),
+                    &Username::from("the-user"),
+                )
+                .await
+                .unwrap(),
+        };
+        OneShotBuilder::new(
+            context.app(),
+            (
+                Method::GET,
+                format!(
+                    "/api/test/users/the-user/activate?{}",
+                    serde_urlencoded::to_string(request).unwrap()
+                ),
+            ),
+        )
+        .send_empty()
+        .await
+        .expect_text("successfully activated")
+        .await;
+
+        let response = OneShotBuilder::new(context.app(), (Method::POST, "/api/test/login"))
+            .with_basic_auth("the-user", "The1234Password")
+            .send_empty()
+            .await
+            .expect_json::<LoginResponse>()
+            .await;
+        let access_token1 = response.access_token;
+        assert!(context.session_exists(&access_token1).await);
+
+        let response = OneShotBuilder::new(context.app(), (Method::POST, "/api/test/login"))
+            .with_basic_auth("the-user", "The1234Password")
+            .send_empty()
+            .await
+            .expect_json::<LoginResponse>()
+            .await;
+        let access_token2 = response.access_token;
+        assert!(context.session_exists(&access_token1).await);
+        assert!(context.session_exists(&access_token2).await);
+
+        assert_ne!(access_token1, access_token2);
+
+        OneShotBuilder::new(context.app(), (Method::POST, "/api/test/users/the-user/logout"))
+            .with_bearer_auth(access_token1.as_str())
+            .send_empty()
+            .await
+            .expect_empty()
+            .await;
+        assert!(!context.session_exists(&access_token1).await);
+        assert!(context.session_exists(&access_token2).await);
+    }
+}

--- a/authn/src/rest/mod.rs
+++ b/authn/src/rest/mod.rs
@@ -23,8 +23,8 @@ mod api_login_post;
 mod api_logout_post;
 mod api_signup_post;
 mod httputils;
-#[cfg(test)]
-mod testutils;
+#[cfg(any(test, feature = "testutils"))]
+pub mod testutils;
 
 pub use api_activate_get::ActivateRequest;
 pub use api_login_post::LoginResponse;

--- a/authn/src/rest/testutils.rs
+++ b/authn/src/rest/testutils.rs
@@ -72,7 +72,7 @@ impl TestContext {
 
     /// Creates the `whoami` user by directly modifying the backing database. The user is marked
     /// as inactive with a pending activation `code`.
-    pub(crate) async fn create_inactive_whoami_user(&mut self, code: u32) -> User {
+    pub(crate) async fn create_inactive_whoami_user(&mut self, code: u64) -> User {
         let user = self.create_whoami_user().await;
         assert!(user.activation_code().is_none());
 
@@ -132,7 +132,7 @@ impl TestContext {
         &self,
         email: &EmailAddress,
         exp_username: &Username,
-    ) -> Option<u32> {
+    ) -> Option<u64> {
         get_latest_activation_code(&self.mailer, email, exp_username).await
     }
 }

--- a/authn/src/rest/testutils.rs
+++ b/authn/src/rest/testutils.rs
@@ -141,12 +141,19 @@ impl TestContext {
 #[must_use]
 pub(crate) struct TestContextBuilder {
     whoami: String,
+    activated_template: Option<&'static str>,
 }
 
 impl TestContextBuilder {
     /// Initializes a new builder with the default test settings.
     pub(crate) fn new() -> Self {
-        Self { whoami: "whoami".to_owned() }
+        Self { whoami: "whoami".to_owned(), activated_template: None }
+    }
+
+    /// Overrides the default activated template.
+    pub(crate) fn with_activated_template(mut self, template: &'static str) -> Self {
+        self.activated_template = Some(template);
+        self
     }
 
     /// Overrides the default test user's identifier.  The identifier needn't be valid.
@@ -171,7 +178,7 @@ impl TestContextBuilder {
             "the-realm",
             AuthnOptions::default(),
         );
-        let app = Router::new().nest("/api/test", app(driver.clone()));
+        let app = Router::new().nest("/api/test", app(driver.clone(), self.activated_template));
 
         let whoami_password = Password::new(format!("random-{}", rand::random::<u32>())).unwrap();
 

--- a/authn/src/rest/testutils.rs
+++ b/authn/src/rest/testutils.rs
@@ -1,0 +1,180 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use crate::db;
+use crate::driver::email::testutils::{get_latest_activation_code, make_test_activation_template};
+use crate::driver::{AuthnDriver, AuthnOptions};
+use crate::model::{AccessToken, HashedPassword, Password, User};
+use crate::rest::app;
+use axum::Router;
+use iii_iv_core::clocks::testutils::MonotonicClock;
+use iii_iv_core::db::{Db, DbError};
+use iii_iv_core::model::{EmailAddress, Username};
+use iii_iv_core::rest::BaseUrls;
+use iii_iv_lettre::testutils::RecorderSmtpMailer;
+use std::sync::Arc;
+use time::OffsetDateTime;
+
+/// State of a running test.
+pub(crate) struct TestContext {
+    app: Router,
+    db: Arc<dyn Db + Send + Sync>,
+    whoami: String,
+    whoami_password: Password,
+    mailer: Arc<RecorderSmtpMailer>,
+    driver: AuthnDriver,
+}
+
+impl TestContext {
+    /// Creates the `whoami` user by directly modifying the backing database. The user is marked
+    /// as active.
+    pub(crate) async fn create_whoami_user(&mut self) -> User {
+        let password = self.whoami_password.clone().validate_and_hash(|_| None).unwrap();
+
+        let user = User::new(self.whoami(), EmailAddress::from("whoami@example.com"))
+            .with_password(password)
+            .with_last_login(OffsetDateTime::from_unix_timestamp(100100).unwrap());
+        db::create_user(
+            &mut self.db.ex(),
+            user.username().clone(),
+            user.password().map(HashedPassword::clone),
+            user.email().clone(),
+        )
+        .await
+        .unwrap();
+        db::update_user(&mut self.db.ex(), user.username().clone(), user.last_login().unwrap())
+            .await
+            .unwrap();
+        user
+    }
+
+    /// Consumes the context and transforms it into the app router.
+    pub(crate) fn into_app(self) -> Router {
+        self.app
+    }
+
+    /// Gets a clone of the app router.
+    pub(crate) fn app(&self) -> Router {
+        self.app.clone()
+    }
+
+    /// Creates the `whoami` user by directly modifying the backing database. The user is marked
+    /// as inactive with a pending activation `code`.
+    pub(crate) async fn create_inactive_whoami_user(&mut self, code: u32) -> User {
+        let user = self.create_whoami_user().await;
+        assert!(user.activation_code().is_none());
+
+        db::set_user_activation_code(&mut self.db.ex(), user, Some(code)).await.unwrap()
+    }
+
+    /// Checks if the user with `username` exists by directly querying the backing database.
+    pub(crate) async fn user_exists(&mut self, username: &Username) -> bool {
+        match db::get_user_by_username(&mut self.db.ex(), username.clone()).await {
+            Ok(_) => true,
+            Err(DbError::NotFound) => false,
+            Err(e) => panic!("{:?}", e),
+        }
+    }
+
+    /// Checks if the user with `username` exists and is active by directly querying the backing
+    /// database.
+    pub(crate) async fn user_is_active(&mut self, username: &Username) -> bool {
+        let user = db::get_user_by_username(&mut self.db.ex(), username.clone()).await.unwrap();
+        user.activation_code().is_none()
+    }
+
+    /// Checks if the session with `token` exists by directly querying the backing database.
+    pub(crate) async fn session_exists(&mut self, token: &AccessToken) -> bool {
+        match db::get_session(&mut self.db.ex(), token).await {
+            Ok(_) => true,
+            Err(DbError::NotFound) => false,
+            Err(e) => panic!("{:?}", e),
+        }
+    }
+
+    /// Logs the `whoami` user in and returns its access token.
+    pub(crate) async fn access_token(&self) -> AccessToken {
+        let response = self
+            .driver
+            .clone()
+            .login(Username::new(self.whoami.clone()).unwrap(), self.whoami_password.clone())
+            .await
+            .unwrap();
+        response.take_access_token()
+    }
+
+    /// Returns the "who am I" identifier of the running test. Panics if this context was built
+    /// with an invalid value using the `TestContextBuilder::with_invalid_whoami` method.
+    pub(crate) fn whoami(&self) -> Username {
+        Username::new(&self.whoami).expect("Cannot query invalid whoami")
+    }
+
+    /// Returns the password generated for the "who am I" user of the running test.
+    pub(crate) fn whoami_password(&self) -> &Password {
+        &self.whoami_password
+    }
+
+    /// Gets the latest activation code sent to `email` which, if any, should be for the username
+    /// given in `exp_username`.
+    pub(crate) async fn get_latest_activation_code(
+        &self,
+        email: &EmailAddress,
+        exp_username: &Username,
+    ) -> Option<u32> {
+        get_latest_activation_code(&self.mailer, email, exp_username).await
+    }
+}
+
+/// Builder pattern for the test context.
+#[must_use]
+pub(crate) struct TestContextBuilder {
+    whoami: String,
+}
+
+impl TestContextBuilder {
+    /// Initializes a new builder with the default test settings.
+    pub(crate) fn new() -> Self {
+        Self { whoami: "whoami".to_owned() }
+    }
+
+    /// Overrides the default test user's identifier.  The identifier needn't be valid.
+    pub(crate) fn with_whoami<S: Into<String>>(mut self, whoami: S) -> Self {
+        self.whoami = whoami.into();
+        self
+    }
+
+    /// Sets up the test environment with the configured settings.
+    pub(crate) async fn build(self) -> TestContext {
+        let db = Arc::from(iii_iv_core::db::sqlite::testutils::setup().await);
+        db::init_schema(&mut db.ex()).await.unwrap();
+        let clock = Arc::from(MonotonicClock::new(100000));
+        let mailer = Arc::from(RecorderSmtpMailer::default());
+
+        let driver = AuthnDriver::new(
+            db.clone(),
+            clock,
+            mailer.clone(),
+            make_test_activation_template(),
+            Arc::from(BaseUrls::from_strs("http://localhost:1234/", None)),
+            "the-realm",
+            AuthnOptions::default(),
+        );
+        let app = Router::new().nest("/api/test", app(driver.clone()));
+
+        let whoami_password = Password::new(format!("random-{}", rand::random::<u32>())).unwrap();
+
+        TestContext { app, db, whoami: self.whoami, whoami_password, mailer, driver }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,3 +57,4 @@ pub mod driver;
 pub mod env;
 pub mod model;
 pub mod rest;
+pub mod template;

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -1,0 +1,89 @@
+// III-IV
+// Copyright 2023 Julio Merino
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Trivial templating engine.
+
+/// Performs various named string replacements in `input` based on `replacements`.
+///
+/// The `input` string can have `%key%` strings in it where `key` must appear in `replacements` and
+/// which will be replaced by its corresponding value.  Raw `%` characters can be escaped via `%%`
+/// and nested expansions are not supported.
+pub fn apply(input: &'static str, replacements: &[(&'static str, &str)]) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut partial_key: Option<String> = None;
+    for ch in input.chars() {
+        if ch == '%' {
+            match partial_key {
+                Some(key) if key.is_empty() => {
+                    output.push('%');
+                    partial_key = None;
+                }
+                Some(key) => {
+                    let mut found = false;
+                    for (candidate_key, value) in replacements {
+                        if *candidate_key == key {
+                            assert!(!found, "Found two values for replacement {}", key);
+                            output.push_str(value);
+                            found = true;
+                            // We could "break" here but we don't because we want to check for
+                            // duplicates.
+                        }
+                    }
+                    assert!(found, "No replacement for {} but it must have been defined", key);
+                    partial_key = None;
+                }
+                None => partial_key = Some(String::new()),
+            }
+        } else {
+            match partial_key.as_mut() {
+                Some(k) => k.push(ch),
+                None => output.push(ch),
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_empty() {
+        assert_eq!("", apply("", &[]));
+    }
+
+    #[test]
+    fn test_apply_none() {
+        assert_eq!("this is % some text %%", apply("this is %% some text %%%%", &[]));
+    }
+
+    #[test]
+    fn test_apply_some() {
+        let replacements = &[("a", "single letter"), ("foo", "many letters")];
+        assert_eq!("single lettermany letters", apply("%a%%foo%", replacements));
+        assert_eq!(" single letter many letters ", apply(" %a% %foo% ", replacements));
+        assert_eq!(
+            "some single letter foo text many letters a",
+            apply("some %a% foo text %foo% a", replacements)
+        );
+    }
+
+    #[test]
+    fn test_apply_no_nested_replacements() {
+        let replacements = &[("a", "%nested% chunk")];
+        assert_eq!("the %nested% chunk output", apply("the %a% output", replacements));
+    }
+}


### PR DESCRIPTION
This exposes a new REST API to support user accounts by username and password, as well as a signup flow for them. The code is derived from the EndBASIC Service almost verbatim, with some changes to make it reusable across services.