### PR TITLE
Migrate VSCode config to Even Better TOML

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
     "recommendations": [
-        "bungcip.better-toml",
         "davidanson.vscode-markdownlint",
         "rust-lang.rust-analyzer",
         "stkb.rewrap",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml"
     ]
 }


### PR DESCRIPTION
The previous Better TOML extension for VSCode has been deprecated and suggests migrating to Even Better TOML.