### PR TITLE
Fix testing of features at the workspace level

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -46,7 +46,7 @@ run_tests() {
                 info "Testing ${dir} with default features"
                 cargo test ${cargo_args} -- --include-ignored ${test_args}
             else
-                if grep -q "^{feature} = \[" Cargo.toml; then
+                if [ "${dir}" = . ] || grep -q "^{feature} = \[" Cargo.toml; then
                     info "Testing ${dir} with feature=${feature}"
                     cargo test --features="${feature}" ${cargo_args} -- --include-ignored ${test_args}
                 else


### PR DESCRIPTION
The test.sh script contains logic to avoid testing features that don't exist in the subcrates, but this logic breaks apart when run from the top level.  Fix this by always running with the requested features at the top level.