### PR TITLE
Add missing Hash and Ord traits to model structs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
                   toolchain: stable
                   default: true
                   components: clippy, rustfmt
-            - uses: actions/checkout@v2
-            - uses: mozilla-actions/sccache-action@v0.0.3
+            - uses: actions/checkout@v4
+            - uses: mozilla-actions/sccache-action@v0.0.9
             - run: sudo apt update
             - run: sudo apt install pre-commit
             - run: ./lint.sh
@@ -40,8 +40,8 @@ jobs:
             RUSTC_WRAPPER: "sccache"
             SCCACHE_GHA_ENABLED: "true"
         steps:
-            - uses: actions/checkout@v2
-            - uses: mozilla-actions/sccache-action@v0.0.3
+            - uses: actions/checkout@v4
+            - uses: mozilla-actions/sccache-action@v0.0.9
             - run: ./test.sh all
 
     test-workspace:
@@ -57,6 +57,6 @@ jobs:
             RUSTC_WRAPPER: "sccache"
             SCCACHE_GHA_ENABLED: "true"
         steps:
-            - uses: actions/checkout@v2
-            - uses: mozilla-actions/sccache-action@v0.0.3
+            - uses: actions/checkout@v4
+            - uses: mozilla-actions/sccache-action@v0.0.9
             - run: ./test.sh

--- a/core/src/model/emailaddress.rs
+++ b/core/src/model/emailaddress.rs
@@ -27,7 +27,7 @@ pub(crate) const MAX_EMAIL_LENGTH: usize = 64;
 /// According to the standard, the local part of an email address may be case sensitive but the
 /// domain part is case insensitive.  Given that we only persist email addresses for tracing
 /// purposes, this treats them as case sensitive overall.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct EmailAddress(String);
 

--- a/core/src/model/username.rs
+++ b/core/src/model/username.rs
@@ -25,7 +25,7 @@ pub(crate) const USERS_MAX_USERNAME_LENGTH: usize = 32;
 ///
 /// Usernames are case-insensitive and, for simplicity reasons, we force them to be all in
 /// lowercase.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct Username(String);
 


### PR DESCRIPTION
There is no reason why EmailAddress and Username should not implement these traits -- so add them now.