### PR TITLE
Only run workflows on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 
 name: Test
 
-on: [push, pull_request]
+on: push
 
 jobs:
     lint:


### PR DESCRIPTION
This should avoid duplicate workflow runs when a pull request is created or modified.  We just care about branch changes.